### PR TITLE
Add question paper generator API scaffold

### DIFF
--- a/edpicker-api/Controllers/QuestionPaperController.cs
+++ b/edpicker-api/Controllers/QuestionPaperController.cs
@@ -1,0 +1,67 @@
+using edpicker_api.Models.Dto;
+using edpicker_api.Services.Interface;
+using Microsoft.AspNetCore.Mvc;
+
+namespace edpicker_api.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class QuestionPaperController : ControllerBase
+    {
+        private readonly IQuestionPaperRepository _repository;
+        private readonly ILogger<QuestionPaperController> _logger;
+
+        public QuestionPaperController(IQuestionPaperRepository repository, ILogger<QuestionPaperController> logger)
+        {
+            _repository = repository;
+            _logger = logger;
+        }
+
+        [HttpPost("generate-questions")]
+        public async Task<IActionResult> GenerateQuestions([FromBody] GenerateQuestionsRequestDto request)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+            try
+            {
+                var questions = await _repository.GenerateQuestionsAsync(request);
+                return Ok(questions);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to generate questions");
+                return StatusCode(500, "Error generating questions");
+            }
+        }
+
+        [HttpPost("refresh-question")]
+        public async Task<IActionResult> RefreshQuestion([FromBody] RefreshQuestionRequestDto request)
+        {
+            try
+            {
+                var question = await _repository.RefreshQuestionAsync(request);
+                return Ok(question);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to refresh question");
+                return StatusCode(500, "Error refreshing question");
+            }
+        }
+
+        [HttpPost("download-paper")]
+        public async Task<IActionResult> DownloadPaper([FromBody] DownloadPaperRequestDto request)
+        {
+            try
+            {
+                var bytes = await _repository.GenerateQuestionPaperAsync(request);
+                return File(bytes, "application/pdf", "QuestionPaper.pdf");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to generate paper");
+                return StatusCode(500, "Error generating paper");
+            }
+        }
+    }
+}

--- a/edpicker-api/Models/Dto/DownloadPaperRequestDto.cs
+++ b/edpicker-api/Models/Dto/DownloadPaperRequestDto.cs
@@ -1,0 +1,13 @@
+namespace edpicker_api.Models.Dto
+{
+    public class DownloadPaperRequestDto
+    {
+        public List<QuestionPaperItemDto> Questions { get; set; } = new();
+    }
+
+    public class QuestionPaperItemDto
+    {
+        public string QuestionId { get; set; } = string.Empty;
+        public string QuestionText { get; set; } = string.Empty;
+    }
+}

--- a/edpicker-api/Models/Dto/GenerateQuestionsRequestDto.cs
+++ b/edpicker-api/Models/Dto/GenerateQuestionsRequestDto.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace edpicker_api.Models.Dto
+{
+    public class GenerateQuestionsRequestDto
+    {
+        [Required]
+        public string Subject { get; set; } = string.Empty;
+
+        [Required]
+        public string Topic { get; set; } = string.Empty;
+
+        [Required]
+        public string QuestionType { get; set; } = string.Empty;
+
+        [Required]
+        public string Difficulty { get; set; } = string.Empty;
+
+        [Required]
+        [Range(1, int.MaxValue)]
+        public int NumberOfQuestions { get; set; }
+    }
+}

--- a/edpicker-api/Models/Dto/QuestionDto.cs
+++ b/edpicker-api/Models/Dto/QuestionDto.cs
@@ -1,0 +1,9 @@
+namespace edpicker_api.Models.Dto
+{
+    public class QuestionDto
+    {
+        public string QuestionId { get; set; } = Guid.NewGuid().ToString();
+        public string QuestionText { get; set; } = string.Empty;
+        public string? Hint { get; set; }
+    }
+}

--- a/edpicker-api/Models/Dto/RefreshQuestionRequestDto.cs
+++ b/edpicker-api/Models/Dto/RefreshQuestionRequestDto.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace edpicker_api.Models.Dto
+{
+    public class RefreshQuestionRequestDto
+    {
+        [Required]
+        public string Subject { get; set; } = string.Empty;
+
+        [Required]
+        public string Topic { get; set; } = string.Empty;
+
+        [Required]
+        public string QuestionType { get; set; } = string.Empty;
+
+        [Required]
+        public string Difficulty { get; set; } = string.Empty;
+
+        [Required]
+        public string OldQuestionId { get; set; } = string.Empty;
+    }
+}

--- a/edpicker-api/Program.cs
+++ b/edpicker-api/Program.cs
@@ -21,6 +21,7 @@ builder.Services.AddSingleton(new OpenAI.OpenAIClient(openAiApiKey));
 builder.Services.AddScoped<IJobBoardRepository, JobBoardRepository>();
 builder.Services.AddScoped<ISchoolAccountRepository, SchoolAccountRepository>();
 builder.Services.AddScoped<IJwtTokenService, JwtTokenService>();
+builder.Services.AddScoped<IQuestionPaperRepository, QuestionPaperRepository>();
 builder.Services.AddControllers();
 builder.Services.AddDbContext<EdPickerDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));

--- a/edpicker-api/Services/Interface/IQuestionPaperRepository.cs
+++ b/edpicker-api/Services/Interface/IQuestionPaperRepository.cs
@@ -1,0 +1,11 @@
+using edpicker_api.Models.Dto;
+
+namespace edpicker_api.Services.Interface
+{
+    public interface IQuestionPaperRepository
+    {
+        Task<IEnumerable<QuestionDto>> GenerateQuestionsAsync(GenerateQuestionsRequestDto request);
+        Task<QuestionDto> RefreshQuestionAsync(RefreshQuestionRequestDto request);
+        Task<byte[]> GenerateQuestionPaperAsync(DownloadPaperRequestDto request);
+    }
+}

--- a/edpicker-api/Services/QuestionPaperRepository.cs
+++ b/edpicker-api/Services/QuestionPaperRepository.cs
@@ -1,0 +1,106 @@
+using System.Text;
+using edpicker_api.Models.Dto;
+using edpicker_api.Services.Interface;
+using Microsoft.AspNetCore.Hosting;
+using UglyToad.PdfPig;
+using UglyToad.PdfPig.Content;
+
+namespace edpicker_api.Services
+{
+    public class QuestionPaperRepository : IQuestionPaperRepository
+    {
+        private readonly IWebHostEnvironment _env;
+        private readonly ILogger<QuestionPaperRepository> _logger;
+
+        public QuestionPaperRepository(IWebHostEnvironment env, ILogger<QuestionPaperRepository> logger)
+        {
+            _env = env;
+            _logger = logger;
+        }
+
+        public async Task<IEnumerable<QuestionDto>> GenerateQuestionsAsync(GenerateQuestionsRequestDto request)
+        {
+            var questions = new List<QuestionDto>();
+            try
+            {
+                string pdfPath = Path.Combine(_env.WebRootPath ?? "wwwroot", "PDFs", request.Subject, $"{request.Topic}.pdf");
+                string content = ReadPdfContent(pdfPath);
+                // TODO: Use OpenAI to create questions from content
+                for (int i = 0; i < request.NumberOfQuestions; i++)
+                {
+                    questions.Add(new QuestionDto
+                    {
+                        QuestionId = Guid.NewGuid().ToString(),
+                        QuestionText = $"Sample question {i + 1} for {request.Topic}",
+                        Hint = "Sample hint"
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error generating questions");
+                throw;
+            }
+            return await Task.FromResult(questions);
+        }
+
+        public async Task<QuestionDto> RefreshQuestionAsync(RefreshQuestionRequestDto request)
+        {
+            try
+            {
+                // Generate a new sample question
+                var question = new QuestionDto
+                {
+                    QuestionId = Guid.NewGuid().ToString(),
+                    QuestionText = $"Refreshed question for {request.Topic}",
+                    Hint = "Sample hint"
+                };
+                return await Task.FromResult(question);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error refreshing question");
+                throw;
+            }
+        }
+
+        public async Task<byte[]> GenerateQuestionPaperAsync(DownloadPaperRequestDto request)
+        {
+            try
+            {
+                var sb = new StringBuilder();
+                int count = 1;
+                foreach (var q in request.Questions)
+                {
+                    sb.AppendLine($"{count}. {q.QuestionText}");
+                    sb.AppendLine();
+                    count++;
+                }
+                return await Task.FromResult(Encoding.UTF8.GetBytes(sb.ToString()));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error generating paper");
+                throw;
+            }
+        }
+
+        private string ReadPdfContent(string path)
+        {
+            if (!File.Exists(path))
+            {
+                _logger.LogWarning("PDF not found at {Path}", path);
+                return string.Empty;
+            }
+            var sb = new StringBuilder();
+            using (PdfDocument pdf = PdfDocument.Open(path))
+            {
+                foreach (Page page in pdf.GetPages())
+                {
+                    sb.AppendLine(page.Text);
+                }
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/edpicker-api/edpicker-api.csproj
+++ b/edpicker-api/edpicker-api.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="OpenAI" Version="2.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="UglyToad.PdfPig" Version="0.0.10" />
   </ItemGroup>
 
 </Project>

--- a/edpicker-api/wwwroot/PDFs/Science/Chapter1.pdf
+++ b/edpicker-api/wwwroot/PDFs/Science/Chapter1.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 18 Tf 72 72 Td (Sample Science Chapter 1) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000067 00000 n 
+0000000129 00000 n 
+0000000294 00000 n 
+0000000390 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+452
+%%EOF


### PR DESCRIPTION
## Summary
- add QuestionPaperController with endpoints for generating, refreshing, and downloading questions
- implement QuestionPaperRepository with PDF parsing stub and question generation placeholders
- wire up repository and DTOs; register service and add PdfPig package

## Testing
- `dotnet restore` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895ba00c5cc832a8c67d30c6c0cdedd