### PR TITLE
Add MCQ question type support and introduce responses-based generation

### DIFF
--- a/edpicker-api/Controllers/QuestionPaperController.cs
+++ b/edpicker-api/Controllers/QuestionPaperController.cs
@@ -34,6 +34,23 @@ namespace edpicker_api.Controllers
             }
         }
 
+        [HttpPost("generate-questions-v2")]
+        public async Task<IActionResult> GenerateQuestionsV2([FromBody] GenerateQuestionsRequestDto request)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+            try
+            {
+                var questions = await _repository.GenerateQuestionsWithResponsesAsync(request);
+                return Ok(questions);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to generate questions (v2)");
+                return StatusCode(500, "Error generating questions");
+            }
+        }
+
         [HttpPost("refresh-question")]
         public async Task<IActionResult> RefreshQuestion([FromBody] RefreshQuestionRequestDto request)
         {

--- a/edpicker-api/Models/Dto/GenerateQuestionsRequestDto.cs
+++ b/edpicker-api/Models/Dto/GenerateQuestionsRequestDto.cs
@@ -1,17 +1,26 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using edpicker_api.Models.Enum;
 
 namespace edpicker_api.Models.Dto
 {
     public class GenerateQuestionsRequestDto
     {
         [Required]
+        public string Class { get; set; } = string.Empty;
+
+        [Required]
         public string Subject { get; set; } = string.Empty;
+
+        [Required]
+        public string Chapter { get; set; } = string.Empty;
 
         [Required]
         public string Topic { get; set; } = string.Empty;
 
         [Required]
-        public string QuestionType { get; set; } = string.Empty;
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public QuestionType QuestionType { get; set; }
 
         [Required]
         public string Difficulty { get; set; } = string.Empty;

--- a/edpicker-api/Models/Dto/QuestionDto.cs
+++ b/edpicker-api/Models/Dto/QuestionDto.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace edpicker_api.Models.Dto
 {
     public class QuestionDto
@@ -5,6 +7,7 @@ namespace edpicker_api.Models.Dto
         public string QuestionId { get; set; } = Guid.NewGuid().ToString();
         public string QuestionText { get; set; } = string.Empty;
         public string? Hint { get; set; }
-        public string ? Answer { get; set; }
+        public List<string>? Options { get; set; }
+        public string? Answer { get; set; }
     }
 }

--- a/edpicker-api/Models/Dto/RefreshQuestionRequestDto.cs
+++ b/edpicker-api/Models/Dto/RefreshQuestionRequestDto.cs
@@ -1,4 +1,6 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using edpicker_api.Models.Enum;
 
 namespace edpicker_api.Models.Dto
 {
@@ -11,7 +13,8 @@ namespace edpicker_api.Models.Dto
         public string Topic { get; set; } = string.Empty;
 
         [Required]
-        public string QuestionType { get; set; } = string.Empty;
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public QuestionType QuestionType { get; set; }
 
         [Required]
         public string Difficulty { get; set; } = string.Empty;

--- a/edpicker-api/Models/Enum/QuestionType.cs
+++ b/edpicker-api/Models/Enum/QuestionType.cs
@@ -1,0 +1,10 @@
+namespace edpicker_api.Models.Enum
+{
+    public enum QuestionType
+    {
+        Short,
+        Long,
+        MCQ
+    }
+}
+

--- a/edpicker-api/Program.cs
+++ b/edpicker-api/Program.cs
@@ -3,13 +3,16 @@ using Azure.Identity;
 using edpicker_api.Models;
 using edpicker_api.Services;
 using edpicker_api.Services.Interface;
+using OpenAI;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
 
-//builder.Services.AddSingleton(new OpenAI.OpenAIClient(theOpenAIKey));
+// Register OpenAI client using API key from configuration
+var openAiKey = builder.Configuration["OpenAIKey"];
+builder.Services.AddSingleton(_ => new OpenAIClient(openAiKey));
 
 // Add services to the container.
 builder.Services.AddScoped<IJobBoardRepository, JobBoardRepository>();

--- a/edpicker-api/Services/Interface/IQuestionPaperRepository.cs
+++ b/edpicker-api/Services/Interface/IQuestionPaperRepository.cs
@@ -5,6 +5,7 @@ namespace edpicker_api.Services.Interface
     public interface IQuestionPaperRepository
     {
         Task<IEnumerable<QuestionDto>> GenerateQuestionsAsync(GenerateQuestionsRequestDto request);
+        Task<IEnumerable<QuestionDto>> GenerateQuestionsWithResponsesAsync(GenerateQuestionsRequestDto request);
         Task<QuestionDto> RefreshQuestionAsync(RefreshQuestionRequestDto request);
         Task<byte[]> GenerateQuestionPaperAsync(DownloadPaperRequestDto request);
     }

--- a/edpicker-api/Services/QuestionPaperRepository.cs
+++ b/edpicker-api/Services/QuestionPaperRepository.cs
@@ -1,10 +1,15 @@
 using System.Text;
 using edpicker_api.Models.Dto;
+using edpicker_api.Models.Enum;
 using edpicker_api.Models.Methods;
 using edpicker_api.Services.Interface;
 using Microsoft.AspNetCore.Hosting;
 using UglyToad.PdfPig;
 using UglyToad.PdfPig.Content;
+using OpenAI;
+using OpenAI.Assistants;
+using OpenAI.Responses;
+using Newtonsoft.Json;
 
 namespace edpicker_api.Services
 {
@@ -13,13 +18,21 @@ namespace edpicker_api.Services
         private readonly IWebHostEnvironment _env;
         private readonly ILogger<QuestionPaperRepository> _logger;
         private readonly IConfiguration _configuration;
+        private readonly OpenAIClient _openAIClient;
         private static readonly string[] SentenceDelimiters = { ".", "!", "?" };
 
-        public QuestionPaperRepository(IWebHostEnvironment env, ILogger<QuestionPaperRepository> logger, IConfiguration configuration)
+        // Temporary in-memory mapping; replace with SQL-backed storage later
+        private readonly Dictionary<(string Class, string Subject, string Chapter), (string VectorStoreId, string FileId)> _resourceMap = new()
+        {
+            { ("9", "Science", "Heat"), ("vs_school42_cls9_science_2025", "file_heat_001") }
+        };
+
+        public QuestionPaperRepository(IWebHostEnvironment env, ILogger<QuestionPaperRepository> logger, IConfiguration configuration, OpenAIClient openAIClient)
         {
             _env = env;
             _logger = logger;
             _configuration = configuration;
+            _openAIClient = openAIClient;
         }
 
         public async Task<IEnumerable<QuestionDto>> GenerateQuestionsAsync(GenerateQuestionsRequestDto request)
@@ -47,6 +60,104 @@ namespace edpicker_api.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error generating questions");
+                throw;
+            }
+        }
+
+        public async Task<IEnumerable<QuestionDto>> GenerateQuestionsWithResponsesAsync(GenerateQuestionsRequestDto request)
+        {
+            try
+            {
+                if (!_resourceMap.TryGetValue((request.Class, request.Subject, request.Chapter), out var resources))
+                    throw new ArgumentException($"No resources mapped for class {request.Class}, subject {request.Subject}, chapter {request.Chapter}");
+
+                var (vectorStoreId, fileId) = resources;
+
+                var responsesClient = _openAIClient.GetResponsesClient();
+
+                var promptBuilder = new StringBuilder();
+                promptBuilder.Append($"Create {request.NumberOfQuestions} {request.QuestionType} questions for Class {request.Class} {request.Subject} Chapter {request.Chapter} on topic {request.Topic}. ");
+                promptBuilder.Append($"Difficulty: {request.Difficulty}. Use only the provided textbook chapters as the source. Avoid verbatim copying; keep questions unique and syllabus-aligned. ");
+
+                if (request.QuestionType == QuestionType.MCQ)
+                {
+                    promptBuilder.Append("For each question, provide four options and the index of the correct option.");
+                }
+                else if (request.QuestionType == QuestionType.Short)
+                {
+                    promptBuilder.Append("Each answer should be about two sentences long and include a brief hint.");
+                }
+                else
+                {
+                    promptBuilder.Append("Each answer should be about five sentences long and include a helpful hint.");
+                }
+
+                var schema = new
+                {
+                    type = "object",
+                    properties = new
+                    {
+                        items = new
+                        {
+                            type = "array",
+                            items = new
+                            {
+                                type = "object",
+                                properties = new
+                                {
+                                    QuestionText = new { type = "string" },
+                                    Options = new
+                                    {
+                                        type = "array",
+                                        items = new { type = "string" },
+                                        minItems = 4,
+                                        maxItems = 4
+                                    },
+                                    Answer = new { type = "string" },
+                                    Hint = new { type = "string" }
+                                },
+                                required = request.QuestionType == QuestionType.MCQ
+                                    ? new[] { "QuestionText", "Options", "Answer" }
+                                    : new[] { "QuestionText", "Answer", "Hint" }
+                            }
+                        }
+                    },
+                    required = new[] { "items" }
+                };
+
+                var response = await responsesClient.CreateResponseAsync(new ResponseCreationOptions
+                {
+                    Model = "gpt-4o-mini",
+                    Input = promptBuilder.ToString(),
+                    Tools = { new FileSearchToolDefinition() },
+                    ToolResources = new()
+                    {
+                        FileSearch = new()
+                        {
+                            VectorStoreIds = { vectorStoreId },
+                            FileIds = { fileId }
+                        }
+                    },
+                    ResponseFormat = ResponseFormat.CreateJsonSchema(
+                        name: "question_set",
+                        schema: schema,
+                        strict: true)
+                });
+
+                var json = response.Output[0].Content[0].Text;
+                var questions = JsonConvert.DeserializeObject<List<QuestionDto>>(json) ?? new List<QuestionDto>();
+
+                foreach (var q in questions)
+                {
+                    if (string.IsNullOrEmpty(q.QuestionId))
+                        q.QuestionId = Guid.NewGuid().ToString();
+                }
+
+                return questions;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error generating questions via responses API");
                 throw;
             }
         }
@@ -230,13 +341,35 @@ namespace edpicker_api.Services
             {
                 var question = new QuestionDto
                 {
-                    QuestionId = Guid.NewGuid().ToString(),
-                    QuestionText = $"What are the key concepts in {request.Topic} related to {request.Subject}? (Question {i + 1})",
-                    Hint = $"Think about the fundamental principles and applications in {request.Topic}",
-                    Answer = request.QuestionType.ToLower().Contains("short")
-                        ? $"Key concepts in {request.Topic} include fundamental principles and their practical applications in {request.Subject}."
-                        : $"The key concepts in {request.Topic} encompass a comprehensive understanding of fundamental principles, theoretical frameworks, practical applications, and real-world implications. These concepts form the foundation for advanced study in {request.Subject} and provide essential knowledge for understanding complex relationships and processes within this field of study."
+                    QuestionId = Guid.NewGuid().ToString()
                 };
+
+                switch (request.QuestionType)
+                {
+                    case QuestionType.MCQ:
+                        question.QuestionText = $"Which option best describes {request.Topic}? (Question {i + 1})";
+                        question.Hint = $"Review the concepts of {request.Topic}";
+                        question.Options = new List<string>
+                        {
+                            $"Option A about {request.Topic}",
+                            $"Option B about {request.Topic}",
+                            $"Option C about {request.Topic}",
+                            $"Option D about {request.Topic}"
+                        };
+                        question.Answer = question.Options[0];
+                        break;
+                    case QuestionType.Short:
+                        question.QuestionText = $"What are the key concepts in {request.Topic} related to {request.Subject}? (Question {i + 1})";
+                        question.Hint = $"Think about the fundamental principles and applications in {request.Topic}";
+                        question.Answer = $"Key concepts in {request.Topic} include fundamental principles and their practical applications in {request.Subject}.";
+                        break;
+                    default:
+                        question.QuestionText = $"Explain the key concepts in {request.Topic} related to {request.Subject}. (Question {i + 1})";
+                        question.Hint = $"Provide a detailed explanation covering various aspects of {request.Topic}";
+                        question.Answer = $"The key concepts in {request.Topic} encompass a comprehensive understanding of fundamental principles, theoretical frameworks, practical applications, and real-world implications. These concepts form the foundation for advanced study in {request.Subject} and provide essential knowledge for understanding complex relationships and processes within this field of study.";
+                        break;
+                }
+
                 fallbackQuestions.Add(question);
             }
 
@@ -299,43 +432,61 @@ namespace edpicker_api.Services
             string contentChunk,
             int numberOfQuestions)
         {
-            var prompt = $@"
-You are an expert question paper generator for school students.
+            var promptBuilder = new StringBuilder();
+            promptBuilder.AppendLine("You are an expert question paper generator for school students.");
+            promptBuilder.AppendLine();
+            promptBuilder.AppendLine("Based on the following content:");
+            promptBuilder.AppendLine("---");
+            promptBuilder.AppendLine(contentChunk);
+            promptBuilder.AppendLine("---");
+            promptBuilder.AppendLine();
+            promptBuilder.AppendLine($"Generate {numberOfQuestions} {request.QuestionType} questions for the subject \"{request.Subject}\" on the topic \"{request.Topic}\".");
+            promptBuilder.AppendLine($"The questions should be at \"{request.Difficulty}\" difficulty level.");
 
-Based on the following content:
----
-{contentChunk}
----
+            if (request.QuestionType == QuestionType.MCQ)
+            {
+                promptBuilder.AppendLine("For each question, provide:");
+                promptBuilder.AppendLine("- The question text");
+                promptBuilder.AppendLine("- Four options");
+                promptBuilder.AppendLine("- The correct answer (one of the options)");
+                promptBuilder.AppendLine("Format your response as a JSON array of objects with \"QuestionText\", \"Options\" (array of four strings), and \"Answer\" (the correct option text).");
+                promptBuilder.AppendLine("Example:");
+                promptBuilder.AppendLine("[");
+                promptBuilder.AppendLine("  { \"QuestionText\": \"Sample question?\", \"Options\": [\"Option 1\", \"Option 2\", \"Option 3\", \"Option 4\"], \"Answer\": \"Option 1\" }");
+                promptBuilder.AppendLine("]");
+            }
+            else
+            {
+                promptBuilder.AppendLine("For each question, provide:");
+                promptBuilder.AppendLine("- The question text");
+                promptBuilder.AppendLine("- A helpful hint");
+                promptBuilder.AppendLine("- An answer based on the question type (2 lines for short answers, 5 lines for long answers)");
+                promptBuilder.AppendLine("Format your response as a JSON array of objects, each with \"QuestionText\", \"Hint\", and \"Answer\" properties.");
+                promptBuilder.AppendLine("Example:");
+                promptBuilder.AppendLine("[");
+                promptBuilder.AppendLine("  { \"QuestionText\": \"Sample question 1...\", \"Hint\": \"Sample hint 1\", \"Answer\": \"Answer\" },");
+                promptBuilder.AppendLine("  { \"QuestionText\": \"Sample question 2...\", \"Hint\": \"Sample hint 2\", \"Answer\": \"Answer\" }");
+                promptBuilder.AppendLine("]");
+            }
 
-Generate {numberOfQuestions} {request.QuestionType} questions for the subject ""{request.Subject}"" on the topic ""{request.Topic}"".
-The questions should be at ""{request.Difficulty}"" difficulty level. 
-For each question, provide:
-- The question text
-- A helpful hint
-- And Answer based on the {request.QuestionType} if it is short need in 2 line if it is long need it in 5 line
-
-Format your response as a JSON array of objects, each with ""QuestionText"" and ""Hint"" properties.
-
-Example:
-[
-  {{ ""QuestionText"": ""Sample question 1..."", ""Hint"": ""Sample hint 1"",""Answer"": ""Answer"" }},
-  {{ ""QuestionText"": ""Sample question 2..."", ""Hint"": ""Sample hint 2"",""Answer"": ""Answer"" }}
-]
-";
+            var prompt = promptBuilder.ToString();
 
             try
             {
-                string response = await openAiHelper.GetAnswerFromGPTAsync("", prompt);
+                string response = await openAiHelper.GetAnswerFromGPTAsync(string.Empty, prompt);
 
-                // Deserialize the response to List<QuestionDto>
                 var questions = Newtonsoft.Json.JsonConvert.DeserializeObject<List<QuestionDto>>(response)
                                ?? new List<QuestionDto>();
 
-                // Assign unique IDs
                 foreach (var q in questions)
                     q.QuestionId = Guid.NewGuid().ToString();
 
                 return questions;
+            }
+            catch (Newtonsoft.Json.JsonException jsonEx)
+            {
+                _logger.LogError(jsonEx, "Failed to deserialize questions from OpenAI response");
+                return new List<QuestionDto>();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- Register OpenAI client for dependency injection
- Use class/subject/chapter mapping to resolve vector store and file ids dynamically
- Implement v2 question generation via OpenAI Responses API and expose `generate-questions-v2`

## Testing
- ❌ `dotnet build edpicker-api.sln` (command not found: dotnet)


------
https://chatgpt.com/codex/tasks/task_e_68a4306aa048832a8c647bd656f7725e