### PR TITLE
Add login authentication with JWT tokens

### DIFF
--- a/edpicker-api/Controllers/LoginController.cs
+++ b/edpicker-api/Controllers/LoginController.cs
@@ -1,0 +1,35 @@
+using edpicker_api.Models.Dto;
+using edpicker_api.Services.Interface;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+
+namespace edpicker_api.Controllers
+{
+    [ApiController]
+    [Route("api/auth")]
+    public class LoginController : ControllerBase
+    {
+        private readonly ILoginRepository _loginRepository;
+
+        public LoginController(ILoginRepository loginRepository)
+        {
+            _loginRepository = loginRepository;
+        }
+
+        [HttpPost("login")]
+        public async Task<IActionResult> Login([FromBody] LoginRequestDto request)
+        {
+            try
+            {
+                var result = await _loginRepository.LoginAsync(request);
+                if (result == null)
+                    return Unauthorized();
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, ex.Message);
+            }
+        }
+    }
+}

--- a/edpicker-api/Models/Dto/LoginRequestDto.cs
+++ b/edpicker-api/Models/Dto/LoginRequestDto.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace edpicker_api.Models.Dto
+{
+    public class LoginRequestDto
+    {
+        [JsonPropertyName("schoolCode")]
+        public string SchoolCode { get; set; }
+
+        [JsonPropertyName("username")]
+        public string Username { get; set; }
+
+        [JsonPropertyName("password")]
+        public string Password { get; set; }
+    }
+}

--- a/edpicker-api/Models/Dto/LoginResponseDto.cs
+++ b/edpicker-api/Models/Dto/LoginResponseDto.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace edpicker_api.Models.Dto
+{
+    public class LoginResponseDto
+    {
+        [JsonPropertyName("userId")]
+        public string UserId { get; set; }
+
+        [JsonPropertyName("schoolId")]
+        public int SchoolId { get; set; }
+
+        [JsonPropertyName("schoolName")]
+        public string SchoolName { get; set; }
+
+        [JsonPropertyName("token")]
+        public string Token { get; set; }
+
+        [JsonPropertyName("expiryDate")]
+        public DateTime ExpiryDate { get; set; }
+    }
+}

--- a/edpicker-api/Models/UserCredential.cs
+++ b/edpicker-api/Models/UserCredential.cs
@@ -1,0 +1,12 @@
+namespace edpicker_api.Models
+{
+    public class UserCredential
+    {
+        public string UserId { get; set; }
+        public int SchoolId { get; set; }
+        public string PasswordHash { get; set; }
+        public DateTime ExpiryDateUtc { get; set; }
+        public bool IsDeleted { get; set; }
+        public string SchoolName { get; set; }
+    }
+}

--- a/edpicker-api/Program.cs
+++ b/edpicker-api/Program.cs
@@ -31,6 +31,7 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddApplicationInsightsTelemetry();
 builder.Services.AddScoped<IUserRepository, UserRepository>();
 builder.Services.AddScoped<ICommonRepository, CommonRepository>();
+builder.Services.AddScoped<ILoginRepository, LoginRepository>();
 builder.Services.AddHttpClient();
 // Configure CORS
 builder.Services.AddCors(options =>

--- a/edpicker-api/Services/Interface/IJwtTokenService.cs
+++ b/edpicker-api/Services/Interface/IJwtTokenService.cs
@@ -6,5 +6,7 @@ namespace edpicker_api.Services.Interface
     {
         string GenerateToken(SchoolAccounts user);
         string GenerateToken(User user);
+        string GenerateToken(string userId, int schoolId, string schoolName);
+        string GenerateRefreshToken();
     }
 }

--- a/edpicker-api/Services/Interface/ILoginRepository.cs
+++ b/edpicker-api/Services/Interface/ILoginRepository.cs
@@ -1,0 +1,9 @@
+using edpicker_api.Models.Dto;
+
+namespace edpicker_api.Services.Interface
+{
+    public interface ILoginRepository
+    {
+        Task<LoginResponseDto?> LoginAsync(LoginRequestDto request);
+    }
+}

--- a/edpicker-api/Services/JwtTokenService.cs
+++ b/edpicker-api/Services/JwtTokenService.cs
@@ -77,4 +77,51 @@ public class JwtTokenService : IJwtTokenService
             return e.ToString();
         }
     }
+
+    public string GenerateToken(string userId, int schoolId, string schoolName)
+    {
+        try
+        {
+            var claims = new[]
+            {
+                new Claim(JwtRegisteredClaimNames.Sub, userId),
+                new Claim("userId", userId),
+                new Claim("schoolId", schoolId.ToString()),
+                new Claim("schoolName", schoolName ?? string.Empty),
+                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+            };
+
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]));
+            var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+            var token = new JwtSecurityToken(
+                issuer: _config["Jwt:Issuer"],
+                audience: _config["Jwt:Audience"],
+                claims: claims,
+                expires: DateTime.Now.AddMinutes(Convert.ToInt32(_config["Jwt:ExpireMinutes"])),
+                signingCredentials: creds
+            );
+
+            return new JwtSecurityTokenHandler().WriteToken(token);
+        }
+        catch (Exception e)
+        {
+            return e.ToString();
+        }
+    }
+
+    public string GenerateRefreshToken()
+    {
+        try
+        {
+            var randomNumber = new byte[32];
+            using var rng = System.Security.Cryptography.RandomNumberGenerator.Create();
+            rng.GetBytes(randomNumber);
+            return Convert.ToBase64String(randomNumber);
+        }
+        catch (Exception e)
+        {
+            return e.ToString();
+        }
+    }
 }

--- a/edpicker-api/Services/LoginRepository.cs
+++ b/edpicker-api/Services/LoginRepository.cs
@@ -1,0 +1,55 @@
+using System.Data;
+using Dapper;
+using edpicker_api.Models;
+using edpicker_api.Models.Dto;
+using edpicker_api.Services.Interface;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
+using BCryptNet = BCrypt.Net.BCrypt;
+
+namespace edpicker_api.Services
+{
+    public class LoginRepository : ILoginRepository
+    {
+        private readonly IConfiguration _configuration;
+        private readonly IJwtTokenService _jwtTokenService;
+
+        public LoginRepository(IConfiguration configuration, IJwtTokenService jwtTokenService)
+        {
+            _configuration = configuration;
+            _jwtTokenService = jwtTokenService;
+        }
+
+        public async Task<LoginResponseDto?> LoginAsync(LoginRequestDto request)
+        {
+            try
+            {
+                using IDbConnection db = new SqlConnection(_configuration.GetConnectionString("DefaultConnection"));
+                var parameters = new { SchoolCode = request.SchoolCode, UserId = request.Username, Password = request.Password };
+                var user = await db.QueryFirstOrDefaultAsync<UserCredential>(
+                    "dbo.User_LoginValidate",
+                    parameters,
+                    commandType: CommandType.StoredProcedure);
+                if (user == null)
+                    return null;
+                if (user.IsDeleted || user.ExpiryDateUtc <= DateTime.UtcNow)
+                    return null;
+                if (!BCryptNet.Verify(request.Password, user.PasswordHash))
+                    return null;
+                var token = _jwtTokenService.GenerateToken(user.UserId, user.SchoolId, user.SchoolName);
+                return new LoginResponseDto
+                {
+                    UserId = user.UserId,
+                    SchoolId = user.SchoolId,
+                    SchoolName = user.SchoolName,
+                    Token = token,
+                    ExpiryDate = user.ExpiryDateUtc
+                };
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+        }
+    }
+}

--- a/edpicker-api/edpicker-api.csproj
+++ b/edpicker-api/edpicker-api.csproj
@@ -24,12 +24,14 @@
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.17" />
 		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="OpenAI" Version="2.2.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-		<PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-		<PackageReference Include="UglyToad.PdfPig" Version="1.7.0-custom-5" />
-	</ItemGroup>
+                <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
+                <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+                <PackageReference Include="OpenAI" Version="2.2.0" />
+                <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+                <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+                <PackageReference Include="UglyToad.PdfPig" Version="1.7.0-custom-5" />
+                <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+                <PackageReference Include="Dapper" Version="2.0.123" />
+        </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add LoginController with /api/auth/login endpoint
- implement LoginRepository and DTOs for credential validation
- extend JwtTokenService for refresh tokens and user-specific JWT creation
- use stored procedure for user validation in login flow

## Testing
- `dotnet restore` *(command not found: dotnet)*
- `apt-get update` *(403 Forbidden)*
- `apt-get install -y dotnet-sdk-8.0` *(package not found)*
- `dotnet build` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bd81a38650832a89f6eb9f2d0dfe4e