### PR TITLE
Add SyllabusTracker controller scaffolding

### DIFF
--- a/edpicker-api/Controllers/SyllabusTrackerController.cs
+++ b/edpicker-api/Controllers/SyllabusTrackerController.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using edpicker_api.Services.Interface;
+using edpicker_api.Models.Dto.SyllabusTracker;
+
+namespace edpicker_api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class SyllabusTrackerController : ControllerBase
+    {
+        private readonly ISyllabusTrackerRepository _repository;
+
+        public SyllabusTrackerController(ISyllabusTrackerRepository repository)
+        {
+            _repository = repository;
+        }
+
+        [HttpPost("syllabus")]
+        public async Task<IActionResult> CreateSchool([FromBody] SchoolCreateDto request)
+        {
+            var id = await _repository.CreateSchoolAsync(request);
+            return Ok(new { SchoolId = id });
+        }
+
+        [HttpPut("syllabus/{schoolId}/settings")]
+        public async Task<IActionResult> SetSettings(int schoolId, [FromBody] SchoolSettingsDto request)
+        {
+            await _repository.SetSchoolSettingsAsync(schoolId, request);
+            return NoContent();
+        }
+
+        [HttpPost("syllabus/{schoolId}/teachers")]
+        public async Task<IActionResult> CreateTeacher(int schoolId, [FromBody] TeacherDto request)
+        {
+            var teacher = await _repository.CreateTeacherAsync(schoolId, request);
+            return Ok(teacher);
+        }
+
+        [HttpDelete("syllabus/{schoolId}/teachers/{teacherId}")]
+        public async Task<IActionResult> RemoveTeacher(int schoolId, int teacherId)
+        {
+            await _repository.RemoveTeacherAsync(schoolId, teacherId);
+            return NoContent();
+        }
+
+        [HttpPost("syllabus/{schoolId}/AddClasses")]
+        public async Task<IActionResult> AddClass(int schoolId, [FromBody] ClassDto request)
+        {
+            var cls = await _repository.AddClassAsync(schoolId, request);
+            return Ok(cls);
+        }
+
+        [HttpPost("syllabus/{schoolId}/classes/{classId}/subjects")]
+        public async Task<IActionResult> AddSubject(int schoolId, int classId, [FromBody] SubjectDto request)
+        {
+            var subject = await _repository.AddSubjectAsync(schoolId, classId, request);
+            return Ok(subject);
+        }
+
+        [HttpPost("syllabus/{schoolId}/subjects/{subjectId}/chapters")]
+        public async Task<IActionResult> AddChapter(int schoolId, int subjectId, [FromBody] ChapterDto request)
+        {
+            var chapter = await _repository.AddChapterAsync(schoolId, subjectId, request);
+            return Ok(chapter);
+        }
+
+        [HttpPost("syllabus/{schoolId}/chapters/{chapterId}/topics")]
+        public async Task<IActionResult> AddTopic(int schoolId, int chapterId, [FromBody] TopicDto request)
+        {
+            var topic = await _repository.AddTopicAsync(schoolId, chapterId, request);
+            return Ok(topic);
+        }
+
+        [HttpPost("syllabus/{schoolId}/topics/{topicId}/progress")]
+        public async Task<IActionResult> UpdateTopicProgress(int schoolId, int topicId, [FromBody] ProgressUpdateDto request)
+        {
+            await _repository.UpdateTopicProgressAsync(schoolId, topicId, request);
+            return NoContent();
+        }
+
+        [HttpGet("syllabus/{schoolId}/classes/{classId}/progress")]
+        public async Task<IActionResult> GetClassProgress(int schoolId, int classId)
+        {
+            var progress = await _repository.GetClassProgressAsync(schoolId, classId);
+            return Ok(progress);
+        }
+
+        [HttpGet("syllabus/{schoolId}/dashboard")]
+        public async Task<IActionResult> GetDashboard(int schoolId, [FromQuery] DashboardFilterDto filter)
+        {
+            var dashboard = await _repository.GetDashboardAsync(schoolId, filter);
+            return Ok(dashboard);
+        }
+
+        [HttpGet("syllabus/{schoolId}/logs")]
+        public async Task<IActionResult> GetLogs(int schoolId, [FromQuery] LogsFilterDto filter)
+        {
+            var logs = await _repository.GetLogsAsync(schoolId, filter);
+            return Ok(logs);
+        }
+    }
+}

--- a/edpicker-api/Models/Dto/SyllabusTracker/SyllabusTrackerDtos.cs
+++ b/edpicker-api/Models/Dto/SyllabusTracker/SyllabusTrackerDtos.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+
+namespace edpicker_api.Models.Dto.SyllabusTracker
+{
+    public class SchoolCreateDto
+    {
+        public string Name { get; set; }
+    }
+
+    public class SchoolSettingsDto
+    {
+        public DateTime StartDate { get; set; }
+        public int TotalWorkingDays { get; set; }
+    }
+
+    public class TeacherDto
+    {
+        public string Name { get; set; }
+        public string Email { get; set; }
+        public string Password { get; set; }
+    }
+
+    public class ClassDto
+    {
+        public string Name { get; set; }
+    }
+
+    public class SubjectDto
+    {
+        public string Name { get; set; }
+        public int? TeacherUserId { get; set; }
+    }
+
+    public class ChapterDto
+    {
+        public string Name { get; set; }
+    }
+
+    public class TopicDto
+    {
+        public string Name { get; set; }
+    }
+
+    public class ProgressUpdateDto
+    {
+        public int Percentage { get; set; }
+        public string UpdatedBy { get; set; }
+    }
+
+    public class ProgressDto
+    {
+        public int Id { get; set; }
+        public int Percentage { get; set; }
+    }
+
+    public class DashboardFilterDto
+    {
+        public int? ClassId { get; set; }
+        public int? TeacherUserId { get; set; }
+        public int? SubjectId { get; set; }
+        public DateTime? StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
+    }
+
+    public class DashboardDto
+    {
+        public List<ProgressDto> Items { get; set; } = new();
+    }
+
+    public class LogsFilterDto
+    {
+        public int? TeacherUserId { get; set; }
+        public int? ClassId { get; set; }
+        public int? SubjectId { get; set; }
+        public DateTime? StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
+    }
+
+    public class AuditLogDto
+    {
+        public DateTime Date { get; set; }
+        public string Description { get; set; }
+    }
+}
+

--- a/edpicker-api/Models/EdPickerDbContext.cs
+++ b/edpicker-api/Models/EdPickerDbContext.cs
@@ -1,5 +1,6 @@
 ﻿using edpicker_api.Models;
 using edpicker_api.Models.Dto;
+using edpicker_api.Models.Dto.SyllabusTracker;
 using edpicker_api.Models.Job;
 using edpicker_api.Models.Results;
 using Microsoft.EntityFrameworkCore;
@@ -65,5 +66,6 @@ public class EdPickerDbContext : DbContext
         modelBuilder.Entity<School_GetProfileDto>().HasNoKey().ToView(null);
         modelBuilder.Entity<School_ChangePasswordResultDto>().HasNoKey().ToView(null);
         modelBuilder.Entity<SchoolClassDto>().HasNoKey().ToView(null);
+        modelBuilder.Entity<ProgressDto>().HasNoKey().ToView(null);
     }
 }

--- a/edpicker-api/Program.cs
+++ b/edpicker-api/Program.cs
@@ -32,6 +32,7 @@ builder.Services.AddApplicationInsightsTelemetry();
 builder.Services.AddScoped<IUserRepository, UserRepository>();
 builder.Services.AddScoped<ICommonRepository, CommonRepository>();
 builder.Services.AddScoped<ILoginRepository, LoginRepository>();
+builder.Services.AddScoped<ISyllabusTrackerRepository, SyllabusTrackerRepository>();
 builder.Services.AddHttpClient();
 // Configure CORS
 builder.Services.AddCors(options =>

--- a/edpicker-api/Services/Interface/ISyllabusTrackerRepository.cs
+++ b/edpicker-api/Services/Interface/ISyllabusTrackerRepository.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using edpicker_api.Models.Dto.SyllabusTracker;
+
+namespace edpicker_api.Services.Interface
+{
+    public interface ISyllabusTrackerRepository
+    {
+        Task<int> CreateSchoolAsync(SchoolCreateDto request);
+        Task SetSchoolSettingsAsync(int schoolId, SchoolSettingsDto request);
+        Task<TeacherDto> CreateTeacherAsync(int schoolId, TeacherDto request);
+        Task RemoveTeacherAsync(int schoolId, int teacherId);
+        Task<ClassDto> AddClassAsync(int schoolId, ClassDto request);
+        Task<SubjectDto> AddSubjectAsync(int schoolId, int classId, SubjectDto request);
+        Task<ChapterDto> AddChapterAsync(int schoolId, int subjectId, ChapterDto request);
+        Task<TopicDto> AddTopicAsync(int schoolId, int chapterId, TopicDto request);
+        Task UpdateTopicProgressAsync(int schoolId, int topicId, ProgressUpdateDto request);
+        Task<ProgressDto> GetClassProgressAsync(int schoolId, int classId);
+        Task<DashboardDto> GetDashboardAsync(int schoolId, DashboardFilterDto filter);
+        Task<IEnumerable<AuditLogDto>> GetLogsAsync(int schoolId, LogsFilterDto filter);
+    }
+}

--- a/edpicker-api/Services/SyllabusTrackerRepository.cs
+++ b/edpicker-api/Services/SyllabusTrackerRepository.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using edpicker_api.Models.Dto.SyllabusTracker;
+using edpicker_api.Services.Interface;
+using Microsoft.EntityFrameworkCore;
+
+namespace edpicker_api.Services
+{
+    public class SyllabusTrackerRepository : ISyllabusTrackerRepository
+    {
+        private readonly EdPickerDbContext _context;
+
+        public SyllabusTrackerRepository(EdPickerDbContext context)
+        {
+            _context = context;
+        }
+
+        public Task<int> CreateSchoolAsync(SchoolCreateDto request)
+        {
+            // Placeholder – actual implementation will insert into School table and return new ID
+            return Task.FromResult(0);
+        }
+
+        public async Task SetSchoolSettingsAsync(int schoolId, SchoolSettingsDto request)
+        {
+            await _context.Database.ExecuteSqlRawAsync(
+                "IF EXISTS (SELECT 1 FROM dbo.ST_SchoolSettings WHERE SchoolId = {0}) " +
+                "UPDATE dbo.ST_SchoolSettings SET StartDate = {1}, TotalWorkingDays = {2} WHERE SchoolId = {0} " +
+                "ELSE INSERT dbo.ST_SchoolSettings (SchoolId, StartDate, TotalWorkingDays) VALUES ({0}, {1}, {2})",
+                schoolId, request.StartDate, request.TotalWorkingDays);
+        }
+
+        public Task<TeacherDto> CreateTeacherAsync(int schoolId, TeacherDto request)
+        {
+            return Task.FromResult(request);
+        }
+
+        public Task RemoveTeacherAsync(int schoolId, int teacherId)
+        {
+            return Task.CompletedTask;
+        }
+
+        public async Task<ClassDto> AddClassAsync(int schoolId, ClassDto request)
+        {
+            await _context.Database.ExecuteSqlRawAsync(
+                "EXEC dbo.ST_Class_Add @SchoolId = {0}, @Name = {1}",
+                schoolId, request.Name);
+            return request;
+        }
+
+        public async Task<SubjectDto> AddSubjectAsync(int schoolId, int classId, SubjectDto request)
+        {
+            await _context.Database.ExecuteSqlRawAsync(
+                "EXEC dbo.ST_Subject_Add @SchoolId = {0}, @STClassId = {1}, @Name = {2}",
+                schoolId, classId, request.Name);
+            return request;
+        }
+
+        public async Task<ChapterDto> AddChapterAsync(int schoolId, int subjectId, ChapterDto request)
+        {
+            await _context.Database.ExecuteSqlRawAsync(
+                "EXEC dbo.ST_Chapter_Add @SchoolId = {0}, @STSubjectId = {1}, @Name = {2}",
+                schoolId, subjectId, request.Name);
+            return request;
+        }
+
+        public async Task<TopicDto> AddTopicAsync(int schoolId, int chapterId, TopicDto request)
+        {
+            await _context.Database.ExecuteSqlRawAsync(
+                "EXEC dbo.ST_Topic_Add @SchoolId = {0}, @STChapterId = {1}, @Name = {2}",
+                schoolId, chapterId, request.Name);
+            return request;
+        }
+
+        public async Task UpdateTopicProgressAsync(int schoolId, int topicId, ProgressUpdateDto request)
+        {
+            await _context.Database.ExecuteSqlRawAsync(
+                "EXEC dbo.ST_Progress_Add @SchoolId = {0}, @STTopicId = {1}, @Percentage = {2}, @UpdatedBy = {3}",
+                schoolId, topicId, request.Percentage, request.UpdatedBy);
+        }
+
+        public async Task<ProgressDto> GetClassProgressAsync(int schoolId, int classId)
+        {
+            var result = await _context.Set<ProgressDto>()
+                .FromSqlRaw(
+                    "SELECT {1} AS Id, CAST(ISNULL(AVG(sp.SubjectProgress),0) AS INT) AS Percentage " +
+                    "FROM dbo.vST_SubjectProgress sp " +
+                    "JOIN dbo.ST_Subject s ON s.STSubjectId = sp.STSubjectId " +
+                    "WHERE s.SchoolId = {0} AND sp.STClassId = {1}",
+                    schoolId, classId)
+                .AsNoTracking()
+                .FirstOrDefaultAsync();
+
+            return result ?? new ProgressDto { Id = classId, Percentage = 0 };
+        }
+
+        public Task<DashboardDto> GetDashboardAsync(int schoolId, DashboardFilterDto filter)
+        {
+            return Task.FromResult(new DashboardDto());
+        }
+
+        public Task<IEnumerable<AuditLogDto>> GetLogsAsync(int schoolId, LogsFilterDto filter)
+        {
+            IEnumerable<AuditLogDto> logs = Array.Empty<AuditLogDto>();
+            return Task.FromResult(logs);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold SyllabusTracker API with endpoints for syllabus, classes, subjects, topics and progress
- define DTOs and repository interface/implementation
- register SyllabusTracker services in dependency injection container

## Testing
- `dotnet test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbfff0260832a93c2145567bcdc9b