### PR TITLE
Log generated question papers via stored procedure

### DIFF
--- a/edpicker-api/Models/Dto/GenerateQuestionsRequestDto.cs
+++ b/edpicker-api/Models/Dto/GenerateQuestionsRequestDto.cs
@@ -35,5 +35,8 @@ namespace edpicker_api.Models.Dto
         public string Section { get; set; } = "any";
         public int SubjectId { get; set; }
         public int ChapterId { get; set; }
+        public int? SchoolId { get; set; }
+        public int? UserId { get; set; }
+        public string? BrowserIp { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- capture caller metadata such as user, school, and browser IP when generating question papers via the v2 endpoint
- extend the question generation workflow to serialize the produced paper and queue an asynchronous stored procedure call that logs the details
- add helpers to safely extract token usage, build JSON payloads, and execute the logging stored procedure on a fresh DbContext scope

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cafb2ee8b8832ab5672425d6ae22da