### PR TITLE
Add planner curriculum management API

### DIFF
--- a/edpicker-api/Controllers/PlannerController.cs
+++ b/edpicker-api/Controllers/PlannerController.cs
@@ -1,0 +1,510 @@
+using System.Security.Claims;
+using System.Threading.Tasks;
+using edpicker_api.Models.Planner.Requests;
+using edpicker_api.Services.Interface;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace edpicker_api.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("api/[controller]")]
+    public class PlannerController : ControllerBase
+    {
+        private readonly IPlannerRepository _repository;
+        private readonly ILogger<PlannerController> _logger;
+
+        public PlannerController(IPlannerRepository repository, ILogger<PlannerController> logger)
+        {
+            _repository = repository;
+            _logger = logger;
+        }
+
+        [HttpGet("classes")]
+        public async Task<IActionResult> GetClasses()
+        {
+            try
+            {
+                _logger.LogInformation("GET /api/planner/classes called by user {UserId}", GetCurrentUserId());
+                var classes = await _repository.GetClassesAsync();
+                return Ok(classes);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve classes");
+                return StatusCode(500, new { Message = "Error retrieving classes" });
+            }
+        }
+
+        [HttpGet("sections/{classId}")]
+        public async Task<IActionResult> GetSections(int classId)
+        {
+            if (classId <= 0)
+            {
+                return BadRequest(new { Message = "Invalid classId" });
+            }
+
+            try
+            {
+                _logger.LogInformation("GET /api/planner/sections/{ClassId} called by user {UserId}", classId, GetCurrentUserId());
+                var sections = await _repository.GetSectionsByClassAsync(classId);
+                return Ok(sections);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve sections for class {ClassId}", classId);
+                return StatusCode(500, new { Message = "Error retrieving sections" });
+            }
+        }
+
+        [HttpGet("subjects/{classId}")]
+        public async Task<IActionResult> GetSubjects(int classId)
+        {
+            if (classId <= 0)
+            {
+                return BadRequest(new { Message = "Invalid classId" });
+            }
+
+            try
+            {
+                _logger.LogInformation("GET /api/planner/subjects/{ClassId} called by user {UserId}", classId, GetCurrentUserId());
+                var subjects = await _repository.GetSubjectsByClassAsync(classId);
+                return Ok(subjects);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve subjects for class {ClassId}", classId);
+                return StatusCode(500, new { Message = "Error retrieving subjects" });
+            }
+        }
+
+        [HttpGet("templates/{classId}/{subjectId}")]
+        public async Task<IActionResult> GetTemplates(int classId, int subjectId)
+        {
+            try
+            {
+                _logger.LogInformation("GET /api/planner/templates/{ClassId}/{SubjectId} called by user {UserId}", classId, subjectId, GetCurrentUserId());
+                var templates = await _repository.GetTemplatesAsync(classId, subjectId);
+                return Ok(templates);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve templates for class {ClassId} subject {SubjectId}", classId, subjectId);
+                return StatusCode(500, new { Message = "Error retrieving templates" });
+            }
+        }
+
+        [HttpGet("progress/{instanceId}")]
+        public async Task<IActionResult> GetProgress(int instanceId)
+        {
+            try
+            {
+                _logger.LogInformation("GET /api/planner/progress/{InstanceId} called by user {UserId}", instanceId, GetCurrentUserId());
+                var progress = await _repository.GetProgressAsync(instanceId);
+                if (progress == null)
+                {
+                    return NotFound(new { Message = "Curriculum instance not found" });
+                }
+
+                return Ok(progress);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve progress for instance {InstanceId}", instanceId);
+                return StatusCode(500, new { Message = "Error retrieving progress" });
+            }
+        }
+
+        [HttpGet("curriculum/{instanceId}")]
+        public async Task<IActionResult> GetCurriculum(int instanceId)
+        {
+            try
+            {
+                _logger.LogInformation("GET /api/planner/curriculum/{InstanceId} called by user {UserId}", instanceId, GetCurrentUserId());
+                var curriculum = await _repository.GetCurriculumAsync(instanceId);
+                if (curriculum == null)
+                {
+                    return NotFound(new { Message = "Curriculum instance not found" });
+                }
+
+                return Ok(curriculum);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve curriculum for instance {InstanceId}", instanceId);
+                return StatusCode(500, new { Message = "Error retrieving curriculum" });
+            }
+        }
+
+        [HttpPut("topic/{topicId}/complete")]
+        public async Task<IActionResult> UpdateTopicCompletion(int topicId, [FromBody] TopicCompletionUpdateRequest request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            try
+            {
+                _logger.LogInformation("PUT /api/planner/topic/{TopicId}/complete called by user {UserId}", topicId, GetCurrentUserId());
+                var status = await _repository.UpdateTopicCompletionAsync(topicId, request.InstanceId, request.IsCompleted, GetCurrentUserId(), GetRequestIpAddress());
+                return Ok(status);
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogWarning(ex, "Business rule violation while updating topic completion for topic {TopicId} instance {InstanceId}", topicId, request.InstanceId);
+                return Conflict(new { Message = ex.Message });
+            }
+            catch (KeyNotFoundException ex)
+            {
+                _logger.LogWarning(ex, "Resource not found while updating topic completion for topic {TopicId} instance {InstanceId}", topicId, request.InstanceId);
+                return NotFound(new { Message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to update topic completion for topic {TopicId} instance {InstanceId}", topicId, request.InstanceId);
+                return StatusCode(500, new { Message = "Error updating topic completion" });
+            }
+        }
+
+        [HttpGet("multi-section/{classId}/{subjectId}")]
+        public async Task<IActionResult> GetMultiSectionComparison(int classId, int subjectId)
+        {
+            try
+            {
+                _logger.LogInformation("GET /api/planner/multi-section/{ClassId}/{SubjectId} called by user {UserId}", classId, subjectId, GetCurrentUserId());
+                var comparison = await _repository.GetMultiSectionComparisonAsync(classId, subjectId);
+                return Ok(comparison);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve multi-section comparison for class {ClassId} subject {SubjectId}", classId, subjectId);
+                return StatusCode(500, new { Message = "Error retrieving multi-section comparison" });
+            }
+        }
+
+        [HttpGet("curriculum/{instanceId}/paginated")]
+        public async Task<IActionResult> GetPaginatedCurriculum(int instanceId, [FromQuery] int pageNumber = 1, [FromQuery] int pageSize = 20, [FromQuery] string? searchTerm = null, [FromQuery] string filterStatus = "all")
+        {
+            try
+            {
+                _logger.LogInformation("GET /api/planner/curriculum/{InstanceId}/paginated called by user {UserId}", instanceId, GetCurrentUserId());
+                var paginated = await _repository.GetPaginatedTopicsAsync(instanceId, pageNumber, pageSize, searchTerm, filterStatus);
+                return Ok(paginated);
+            }
+            catch (KeyNotFoundException ex)
+            {
+                _logger.LogWarning(ex, "Curriculum instance not found for pagination request. InstanceId {InstanceId}", instanceId);
+                return NotFound(new { Message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve paginated curriculum for instance {InstanceId}", instanceId);
+                return StatusCode(500, new { Message = "Error retrieving curriculum topics" });
+            }
+        }
+
+        [HttpPost("template/assign")]
+        public async Task<IActionResult> AssignTemplate([FromBody] AssignTemplateRequest request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            try
+            {
+                _logger.LogInformation("POST /api/planner/template/assign called by user {UserId}", GetCurrentUserId());
+                var instanceId = await _repository.AssignTemplateAsync(request, GetCurrentUserId(), GetRequestIpAddress());
+                return CreatedAtAction(nameof(GetCurriculum), new { instanceId }, new { InstanceId = instanceId });
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogWarning(ex, "Business rule violation while assigning template. Request: {@Request}", request);
+                return Conflict(new { Message = ex.Message });
+            }
+            catch (KeyNotFoundException ex)
+            {
+                _logger.LogWarning(ex, "Resource not found while assigning template. Request: {@Request}", request);
+                return NotFound(new { Message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to assign template. Request: {@Request}", request);
+                return StatusCode(500, new { Message = "Error assigning template" });
+            }
+        }
+
+        [HttpGet("template/{templateId}/preview")]
+        public async Task<IActionResult> GetTemplatePreview(int templateId)
+        {
+            try
+            {
+                _logger.LogInformation("GET /api/planner/template/{TemplateId}/preview called by user {UserId}", templateId, GetCurrentUserId());
+                var preview = await _repository.GetTemplatePreviewAsync(templateId);
+                if (preview == null)
+                {
+                    return NotFound(new { Message = "Template not found" });
+                }
+
+                return Ok(preview);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve template preview for template {TemplateId}", templateId);
+                return StatusCode(500, new { Message = "Error retrieving template preview" });
+            }
+        }
+
+        [HttpPost("template/create-custom")]
+        public async Task<IActionResult> CreateCustomTemplate([FromBody] CreateCustomTemplateRequest request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            try
+            {
+                _logger.LogInformation("POST /api/planner/template/create-custom called by user {UserId}", GetCurrentUserId());
+                var templateId = await _repository.CreateCustomTemplateAsync(request, GetCurrentUserId(), GetRequestIpAddress());
+                return CreatedAtAction(nameof(GetTemplatePreview), new { templateId }, new { TemplateId = templateId });
+            }
+            catch (KeyNotFoundException ex)
+            {
+                _logger.LogWarning(ex, "Source template not found while creating custom template. SourceTemplateId {SourceTemplateId}", request.SourceTemplateId);
+                return NotFound(new { Message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to create custom template. Request: {@Request}", request);
+                return StatusCode(500, new { Message = "Error creating custom template" });
+            }
+        }
+
+        [HttpPost("archive/template/{templateId}")]
+        public async Task<IActionResult> ArchiveTemplate(int templateId)
+        {
+            try
+            {
+                _logger.LogInformation("POST /api/planner/archive/template/{TemplateId} called by user {UserId}", templateId, GetCurrentUserId());
+                var result = await _repository.ArchiveTemplateAsync(templateId, GetCurrentUserId(), GetRequestIpAddress());
+                return Ok(new { Success = result });
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogWarning(ex, "Business rule violation while archiving template {TemplateId}", templateId);
+                return Conflict(new { Message = ex.Message });
+            }
+            catch (KeyNotFoundException ex)
+            {
+                _logger.LogWarning(ex, "Template {TemplateId} not found for archive", templateId);
+                return NotFound(new { Message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to archive template {TemplateId}", templateId);
+                return StatusCode(500, new { Message = "Error archiving template" });
+            }
+        }
+
+        [HttpGet("archive/templates")]
+        public async Task<IActionResult> GetArchivedTemplates()
+        {
+            try
+            {
+                _logger.LogInformation("GET /api/planner/archive/templates called by user {UserId}", GetCurrentUserId());
+                var templates = await _repository.GetArchivedTemplatesAsync();
+                return Ok(templates);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve archived templates");
+                return StatusCode(500, new { Message = "Error retrieving archived templates" });
+            }
+        }
+
+        [HttpPost("archive/restore/{templateId}")]
+        public async Task<IActionResult> RestoreTemplate(int templateId)
+        {
+            try
+            {
+                _logger.LogInformation("POST /api/planner/archive/restore/{TemplateId} called by user {UserId}", templateId, GetCurrentUserId());
+                var result = await _repository.RestoreTemplateAsync(templateId, GetCurrentUserId(), GetRequestIpAddress());
+                return Ok(new { Success = result });
+            }
+            catch (KeyNotFoundException ex)
+            {
+                _logger.LogWarning(ex, "Template {TemplateId} not found for restore", templateId);
+                return NotFound(new { Message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to restore template {TemplateId}", templateId);
+                return StatusCode(500, new { Message = "Error restoring template" });
+            }
+        }
+
+        [HttpPost("academic-year/create")]
+        public async Task<IActionResult> CreateAcademicYear([FromBody] AcademicYearCreateRequest request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            try
+            {
+                _logger.LogInformation("POST /api/planner/academic-year/create called by user {UserId}", GetCurrentUserId());
+                var academicYearId = await _repository.CreateAcademicYearAsync(request.YearName, request.StartDate, request.EndDate, GetCurrentUserId(), GetRequestIpAddress());
+                return CreatedAtAction(nameof(GetActiveAcademicYear), new { }, new { AcademicYearId = academicYearId });
+            }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogWarning(ex, "Validation error while creating academic year");
+                return BadRequest(new { Message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to create academic year");
+                return StatusCode(500, new { Message = "Error creating academic year" });
+            }
+        }
+
+        [HttpPost("academic-year/freeze")]
+        public async Task<IActionResult> FreezeAcademicYear([FromBody] AcademicYearFreezeRequest request)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            try
+            {
+                _logger.LogInformation("POST /api/planner/academic-year/freeze called by user {UserId}", GetCurrentUserId());
+                var result = await _repository.FreezeAcademicYearAsync(request.AcademicYearId, GetCurrentUserId(), GetRequestIpAddress());
+                return Ok(new { Success = result });
+            }
+            catch (KeyNotFoundException ex)
+            {
+                _logger.LogWarning(ex, "Academic year {AcademicYearId} not found for freeze", request.AcademicYearId);
+                return NotFound(new { Message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to freeze academic year {AcademicYearId}", request.AcademicYearId);
+                return StatusCode(500, new { Message = "Error freezing academic year" });
+            }
+        }
+
+        [HttpGet("academic-year/active")]
+        public async Task<IActionResult> GetActiveAcademicYear()
+        {
+            try
+            {
+                _logger.LogInformation("GET /api/planner/academic-year/active called by user {UserId}", GetCurrentUserId());
+                var year = await _repository.GetActiveAcademicYearAsync();
+                if (year == null)
+                {
+                    return NotFound(new { Message = "No active academic year" });
+                }
+
+                return Ok(year);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to retrieve active academic year");
+                return StatusCode(500, new { Message = "Error retrieving academic year" });
+            }
+        }
+
+        [HttpGet("export/progress/{instanceId}")]
+        public async Task<IActionResult> ExportProgress(int instanceId)
+        {
+            try
+            {
+                _logger.LogInformation("GET /api/planner/export/progress/{InstanceId} called by user {UserId}", instanceId, GetCurrentUserId());
+                var bytes = await _repository.ExportProgressAsync(instanceId);
+                var fileName = $"curriculum-progress-{instanceId}.csv";
+                return File(bytes, "text/csv", fileName);
+            }
+            catch (KeyNotFoundException ex)
+            {
+                _logger.LogWarning(ex, "Curriculum instance {InstanceId} not found for export", instanceId);
+                return NotFound(new { Message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to export progress for instance {InstanceId}", instanceId);
+                return StatusCode(500, new { Message = "Error exporting progress" });
+            }
+        }
+
+        [HttpGet("export/audit/{instanceId}")]
+        public async Task<IActionResult> ExportAudit(int instanceId)
+        {
+            try
+            {
+                _logger.LogInformation("GET /api/planner/export/audit/{InstanceId} called by user {UserId}", instanceId, GetCurrentUserId());
+                var bytes = await _repository.ExportAuditTrailAsync(instanceId);
+                var fileName = $"curriculum-audit-{instanceId}.csv";
+                return File(bytes, "text/csv", fileName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to export audit trail for instance {InstanceId}", instanceId);
+                return StatusCode(500, new { Message = "Error exporting audit trail" });
+            }
+        }
+
+        [HttpGet("validate/data-integrity")]
+        public async Task<IActionResult> ValidateDataIntegrity()
+        {
+            try
+            {
+                _logger.LogInformation("GET /api/planner/validate/data-integrity called by user {UserId}", GetCurrentUserId());
+                var issues = await _repository.ValidateDataIntegrityAsync();
+                return Ok(issues);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to validate data integrity");
+                return StatusCode(500, new { Message = "Error validating data integrity" });
+            }
+        }
+
+        [HttpPost("validate/fix-orphans")]
+        public async Task<IActionResult> FixOrphans()
+        {
+            try
+            {
+                _logger.LogInformation("POST /api/planner/validate/fix-orphans called by user {UserId}", GetCurrentUserId());
+                var count = await _repository.FixOrphanedRecordsAsync();
+                return Ok(new { FixedRecords = count });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to fix orphaned records");
+                return StatusCode(500, new { Message = "Error fixing orphaned records" });
+            }
+        }
+
+        private int? GetCurrentUserId()
+        {
+            var userIdClaim = User.FindFirst("userId")?.Value ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (int.TryParse(userIdClaim, out var userId))
+            {
+                return userId;
+            }
+
+            return null;
+        }
+
+        private string? GetRequestIpAddress()
+        {
+            return HttpContext?.Connection?.RemoteIpAddress?.ToString();
+        }
+    }
+}

--- a/edpicker-api/Models/EdPickerDbContext.cs
+++ b/edpicker-api/Models/EdPickerDbContext.cs
@@ -1,6 +1,7 @@
-﻿using edpicker_api.Models;
+using edpicker_api.Models;
 using edpicker_api.Models.Dto;
 using edpicker_api.Models.Job;
+using edpicker_api.Models.Planner.Entities;
 using edpicker_api.Models.Results;
 using Microsoft.EntityFrameworkCore;
 
@@ -20,6 +21,18 @@ public class EdPickerDbContext : DbContext
     public DbSet<School_ApplicationStatusCountDto> ApplicationStatusCounts { get; set; }
     public DbSet<BoardDto> Boards { get; set; }
     public DbSet<SchoolClassDto> SchoolClasses { get; set; }
+
+    public DbSet<AcademicYear> AcademicYears { get; set; }
+    public DbSet<CurriculumClass> CurriculumClasses { get; set; }
+    public DbSet<Section> Sections { get; set; }
+    public DbSet<Subject> Subjects { get; set; }
+    public DbSet<Template> Templates { get; set; }
+    public DbSet<Unit> Units { get; set; }
+    public DbSet<Chapter> Chapters { get; set; }
+    public DbSet<Topic> Topics { get; set; }
+    public DbSet<CurriculumInstance> CurriculumInstances { get; set; }
+    public DbSet<TopicCompletion> TopicCompletions { get; set; }
+    public DbSet<AuditLog> AuditLogs { get; set; }
 
     public EdPickerDbContext(DbContextOptions<EdPickerDbContext> options)
       : base(options) { }
@@ -57,7 +70,7 @@ public class EdPickerDbContext : DbContext
             eb.HasNoKey();
             eb.ToView(null);
         });
-        modelBuilder.Entity<UserJobApplicationDto>().HasNoKey(); 
+        modelBuilder.Entity<UserJobApplicationDto>().HasNoKey();
         modelBuilder.Entity<School_JobApplicationDto>().HasNoKey().ToView(null);
         modelBuilder.Entity<School_ApplicationStatusCountDto>().HasNoKey().ToView(null);
         modelBuilder.Entity<School_JobListDto>().HasNoKey().ToView(null);
@@ -65,5 +78,80 @@ public class EdPickerDbContext : DbContext
         modelBuilder.Entity<School_GetProfileDto>().HasNoKey().ToView(null);
         modelBuilder.Entity<School_ChangePasswordResultDto>().HasNoKey().ToView(null);
         modelBuilder.Entity<SchoolClassDto>().HasNoKey().ToView(null);
+
+        ConfigurePlannerModel(modelBuilder);
+    }
+
+    private static void ConfigurePlannerModel(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<CurriculumClass>()
+            .HasMany(c => c.Sections)
+            .WithOne(s => s.Class)
+            .HasForeignKey(s => s.ClassId);
+
+        modelBuilder.Entity<CurriculumClass>()
+            .HasMany(c => c.Subjects)
+            .WithOne(s => s.Class)
+            .HasForeignKey(s => s.ClassId);
+
+        modelBuilder.Entity<Template>()
+            .HasIndex(t => new { t.ClassId, t.SubjectId, t.IsArchived })
+            .HasDatabaseName("IX_Template_Lookup");
+
+        modelBuilder.Entity<Template>()
+            .HasOne(t => t.SourceTemplate)
+            .WithMany(t => t.DerivedTemplates)
+            .HasForeignKey(t => t.SourceTemplateId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        modelBuilder.Entity<Template>()
+            .HasMany(t => t.Units)
+            .WithOne(u => u.Template)
+            .HasForeignKey(u => u.TemplateId);
+
+        modelBuilder.Entity<Unit>()
+            .HasIndex(u => new { u.TemplateId, u.IsArchived })
+            .HasDatabaseName("IX_Unit_Template");
+
+        modelBuilder.Entity<Unit>()
+            .HasMany(u => u.Chapters)
+            .WithOne(c => c.Unit)
+            .HasForeignKey(c => c.UnitId);
+
+        modelBuilder.Entity<Chapter>()
+            .HasIndex(c => new { c.UnitId, c.IsArchived })
+            .HasDatabaseName("IX_Chapter_Unit");
+
+        modelBuilder.Entity<Chapter>()
+            .HasMany(c => c.Topics)
+            .WithOne(t => t.Chapter)
+            .HasForeignKey(t => t.ChapterId);
+
+        modelBuilder.Entity<Topic>()
+            .HasIndex(t => new { t.ChapterId, t.IsArchived })
+            .HasDatabaseName("IX_Topic_Chapter");
+
+        modelBuilder.Entity<CurriculumInstance>()
+            .HasIndex(ci => new { ci.AcademicYearId, ci.ClassId, ci.SectionId, ci.SubjectId })
+            .HasDatabaseName("IX_CurriculumInstance_Lookup")
+            .IsUnique();
+
+        modelBuilder.Entity<CurriculumInstance>()
+            .HasMany(ci => ci.TopicCompletions)
+            .WithOne(tc => tc.Instance)
+            .HasForeignKey(tc => tc.InstanceId);
+
+        modelBuilder.Entity<TopicCompletion>()
+            .HasIndex(tc => new { tc.InstanceId, tc.IsCompleted })
+            .HasDatabaseName("IX_TopicCompletion_Instance");
+
+        modelBuilder.Entity<TopicCompletion>()
+            .HasIndex(tc => new { tc.InstanceId, tc.TopicId })
+            .IsUnique();
+
+        modelBuilder.Entity<AcademicYear>()
+            .HasMany(y => y.CurriculumInstances)
+            .WithOne(ci => ci.AcademicYear)
+            .HasForeignKey(ci => ci.AcademicYearId);
     }
 }

--- a/edpicker-api/Models/Planner/Dto/PlannerDtos.cs
+++ b/edpicker-api/Models/Planner/Dto/PlannerDtos.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+
+namespace edpicker_api.Models.Planner.Dto
+{
+    public class ClassSummaryDto
+    {
+        public int ClassId { get; set; }
+        public string ClassName { get; set; } = string.Empty;
+    }
+
+    public class SectionSummaryDto
+    {
+        public int SectionId { get; set; }
+        public string SectionName { get; set; } = string.Empty;
+    }
+
+    public class SubjectSummaryDto
+    {
+        public int SubjectId { get; set; }
+        public string SubjectName { get; set; } = string.Empty;
+    }
+
+    public class TemplateSummaryDto
+    {
+        public int TemplateId { get; set; }
+        public string TemplateName { get; set; } = string.Empty;
+        public string TemplateType { get; set; } = string.Empty;
+        public bool IsArchived { get; set; }
+        public DateTime CreatedDate { get; set; }
+    }
+
+    public class CurriculumProgressDto
+    {
+        public int InstanceId { get; set; }
+        public int TotalTopics { get; set; }
+        public int CompletedTopics { get; set; }
+        public decimal Percentage { get; set; }
+        public string TemplateName { get; set; } = string.Empty;
+        public DateTime? LastUpdated { get; set; }
+    }
+
+    public class CurriculumStructureDto
+    {
+        public int InstanceId { get; set; }
+        public List<CurriculumUnitDto> Units { get; set; } = new();
+    }
+
+    public class CurriculumUnitDto
+    {
+        public int UnitId { get; set; }
+        public string UnitName { get; set; } = string.Empty;
+        public int UnitOrder { get; set; }
+        public List<CurriculumChapterDto> Chapters { get; set; } = new();
+    }
+
+    public class CurriculumChapterDto
+    {
+        public int ChapterId { get; set; }
+        public string ChapterName { get; set; } = string.Empty;
+        public int ChapterOrder { get; set; }
+        public List<CurriculumTopicDto> Topics { get; set; } = new();
+    }
+
+    public class CurriculumTopicDto
+    {
+        public int TopicId { get; set; }
+        public string TopicName { get; set; } = string.Empty;
+        public int TopicOrder { get; set; }
+        public bool IsCompleted { get; set; }
+        public DateTime? CompletedDate { get; set; }
+    }
+
+    public class TopicCompletionStatusDto
+    {
+        public int TopicId { get; set; }
+        public int InstanceId { get; set; }
+        public bool IsCompleted { get; set; }
+        public DateTime? CompletedDate { get; set; }
+        public DateTime UpdatedDate { get; set; }
+    }
+
+    public class SectionProgressComparisonDto
+    {
+        public int SectionId { get; set; }
+        public string SectionName { get; set; } = string.Empty;
+        public string TemplateName { get; set; } = string.Empty;
+        public int? InstanceId { get; set; }
+        public int TotalTopics { get; set; }
+        public int CompletedTopics { get; set; }
+        public decimal Percentage { get; set; }
+        public DateTime? LastUpdated { get; set; }
+    }
+
+    public class PaginatedTopicsResponseDto
+    {
+        public List<CurriculumTopicDto> Topics { get; set; } = new();
+        public int TotalCount { get; set; }
+        public int PageNumber { get; set; }
+        public int PageSize { get; set; }
+        public int TotalPages { get; set; }
+    }
+
+    public class TemplatePreviewDto
+    {
+        public int TemplateId { get; set; }
+        public string TemplateName { get; set; } = string.Empty;
+        public int UnitCount { get; set; }
+        public int ChapterCount { get; set; }
+        public int TopicCount { get; set; }
+        public List<string> UnitNames { get; set; } = new();
+        public List<string> ChapterNames { get; set; } = new();
+        public List<string> TopicNames { get; set; } = new();
+    }
+
+    public class DataIntegrityIssueDto
+    {
+        public string IssueType { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+    }
+
+    public class CurriculumInstanceDto
+    {
+        public int InstanceId { get; set; }
+        public int AcademicYearId { get; set; }
+        public int ClassId { get; set; }
+        public int SectionId { get; set; }
+        public int SubjectId { get; set; }
+        public int TemplateId { get; set; }
+        public DateTime AssignedDate { get; set; }
+        public string TemplateName { get; set; } = string.Empty;
+    }
+
+    public class AcademicYearDto
+    {
+        public int AcademicYearId { get; set; }
+        public string YearName { get; set; } = string.Empty;
+        public DateTime StartDate { get; set; }
+        public DateTime EndDate { get; set; }
+        public bool IsActive { get; set; }
+        public bool IsFrozen { get; set; }
+    }
+}

--- a/edpicker-api/Models/Planner/Entities/CurriculumEntities.cs
+++ b/edpicker-api/Models/Planner/Entities/CurriculumEntities.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace edpicker_api.Models.Planner.Entities
+{
+    [Table("AcademicYear")]
+    public class AcademicYear
+    {
+        [Key]
+        public int AcademicYearId { get; set; }
+
+        [Required, MaxLength(50)]
+        public string YearName { get; set; } = string.Empty;
+
+        public DateTime StartDate { get; set; }
+
+        public DateTime EndDate { get; set; }
+
+        public bool IsActive { get; set; }
+
+        public bool IsFrozen { get; set; }
+
+        public ICollection<CurriculumInstance> CurriculumInstances { get; set; } = new List<CurriculumInstance>();
+    }
+
+    [Table("Class")]
+    public class CurriculumClass
+    {
+        [Key]
+        public int ClassId { get; set; }
+
+        [Required, MaxLength(100)]
+        public string ClassName { get; set; } = string.Empty;
+
+        public DateTime CreatedDate { get; set; }
+
+        public ICollection<Section> Sections { get; set; } = new List<Section>();
+
+        public ICollection<Subject> Subjects { get; set; } = new List<Subject>();
+
+        public ICollection<Template> Templates { get; set; } = new List<Template>();
+    }
+
+    [Table("Section")]
+    public class Section
+    {
+        [Key]
+        public int SectionId { get; set; }
+
+        [ForeignKey(nameof(Class))]
+        public int ClassId { get; set; }
+
+        [Required, MaxLength(25)]
+        public string SectionName { get; set; } = string.Empty;
+
+        public CurriculumClass Class { get; set; } = null!;
+
+        public ICollection<CurriculumInstance> CurriculumInstances { get; set; } = new List<CurriculumInstance>();
+    }
+
+    [Table("Subject")]
+    public class Subject
+    {
+        [Key]
+        public int SubjectId { get; set; }
+
+        [ForeignKey(nameof(Class))]
+        public int ClassId { get; set; }
+
+        [Required, MaxLength(150)]
+        public string SubjectName { get; set; } = string.Empty;
+
+        public CurriculumClass Class { get; set; } = null!;
+
+        public ICollection<Template> Templates { get; set; } = new List<Template>();
+
+        public ICollection<CurriculumInstance> CurriculumInstances { get; set; } = new List<CurriculumInstance>();
+    }
+
+    [Table("Template")]
+    public class Template
+    {
+        [Key]
+        public int TemplateId { get; set; }
+
+        [ForeignKey(nameof(Class))]
+        public int ClassId { get; set; }
+
+        [ForeignKey(nameof(Subject))]
+        public int SubjectId { get; set; }
+
+        public int? SourceTemplateId { get; set; }
+
+        public int? CreatedBy { get; set; }
+
+        [Required, MaxLength(200)]
+        public string TemplateName { get; set; } = string.Empty;
+
+        [Required, MaxLength(50)]
+        public string TemplateType { get; set; } = "System";
+
+        public bool IsArchived { get; set; }
+
+        public DateTime CreatedDate { get; set; }
+
+        public CurriculumClass Class { get; set; } = null!;
+
+        public Subject Subject { get; set; } = null!;
+
+        public Template? SourceTemplate { get; set; }
+
+        public ICollection<Template> DerivedTemplates { get; set; } = new List<Template>();
+
+        public ICollection<Unit> Units { get; set; } = new List<Unit>();
+
+        public ICollection<CurriculumInstance> CurriculumInstances { get; set; } = new List<CurriculumInstance>();
+    }
+
+    [Table("Unit")]
+    public class Unit
+    {
+        [Key]
+        public int UnitId { get; set; }
+
+        [ForeignKey(nameof(Template))]
+        public int TemplateId { get; set; }
+
+        [Required, MaxLength(200)]
+        public string UnitName { get; set; } = string.Empty;
+
+        public int UnitOrder { get; set; }
+
+        public bool IsArchived { get; set; }
+
+        public DateTime CreatedDate { get; set; }
+
+        public Template Template { get; set; } = null!;
+
+        public ICollection<Chapter> Chapters { get; set; } = new List<Chapter>();
+    }
+
+    [Table("Chapter")]
+    public class Chapter
+    {
+        [Key]
+        public int ChapterId { get; set; }
+
+        [ForeignKey(nameof(Unit))]
+        public int UnitId { get; set; }
+
+        [Required, MaxLength(200)]
+        public string ChapterName { get; set; } = string.Empty;
+
+        public int ChapterOrder { get; set; }
+
+        public bool IsArchived { get; set; }
+
+        public DateTime CreatedDate { get; set; }
+
+        public Unit Unit { get; set; } = null!;
+
+        public ICollection<Topic> Topics { get; set; } = new List<Topic>();
+    }
+
+    [Table("Topic")]
+    public class Topic
+    {
+        [Key]
+        public int TopicId { get; set; }
+
+        [ForeignKey(nameof(Chapter))]
+        public int ChapterId { get; set; }
+
+        [Required, MaxLength(250)]
+        public string TopicName { get; set; } = string.Empty;
+
+        public int TopicOrder { get; set; }
+
+        public bool IsArchived { get; set; }
+
+        public DateTime CreatedDate { get; set; }
+
+        public Chapter Chapter { get; set; } = null!;
+
+        public ICollection<TopicCompletion> TopicCompletions { get; set; } = new List<TopicCompletion>();
+    }
+
+    [Table("CurriculumInstance")]
+    public class CurriculumInstance
+    {
+        [Key]
+        public int InstanceId { get; set; }
+
+        [ForeignKey(nameof(AcademicYear))]
+        public int AcademicYearId { get; set; }
+
+        [ForeignKey(nameof(Class))]
+        public int ClassId { get; set; }
+
+        [ForeignKey(nameof(Section))]
+        public int SectionId { get; set; }
+
+        [ForeignKey(nameof(Subject))]
+        public int SubjectId { get; set; }
+
+        [ForeignKey(nameof(Template))]
+        public int TemplateId { get; set; }
+
+        public DateTime AssignedDate { get; set; }
+
+        public AcademicYear AcademicYear { get; set; } = null!;
+
+        public CurriculumClass Class { get; set; } = null!;
+
+        public Section Section { get; set; } = null!;
+
+        public Subject Subject { get; set; } = null!;
+
+        public Template Template { get; set; } = null!;
+
+        public ICollection<TopicCompletion> TopicCompletions { get; set; } = new List<TopicCompletion>();
+    }
+
+    [Table("TopicCompletion")]
+    public class TopicCompletion
+    {
+        [Key]
+        public int CompletionId { get; set; }
+
+        [ForeignKey(nameof(Instance))]
+        public int InstanceId { get; set; }
+
+        [ForeignKey(nameof(Topic))]
+        public int TopicId { get; set; }
+
+        public bool IsCompleted { get; set; }
+
+        public DateTime? CompletedDate { get; set; }
+
+        public DateTime UpdatedDate { get; set; }
+
+        public int? UpdatedBy { get; set; }
+
+        public CurriculumInstance Instance { get; set; } = null!;
+
+        public Topic Topic { get; set; } = null!;
+    }
+
+    [Table("AuditLog")]
+    public class AuditLog
+    {
+        [Key]
+        public long AuditId { get; set; }
+
+        [Required, MaxLength(128)]
+        public string TableName { get; set; } = string.Empty;
+
+        public long RecordId { get; set; }
+
+        [Required, MaxLength(50)]
+        public string Action { get; set; } = string.Empty;
+
+        public string? OldValue { get; set; }
+
+        public string? NewValue { get; set; }
+
+        public DateTime UpdatedDate { get; set; }
+
+        public int? UpdatedBy { get; set; }
+
+        [MaxLength(64)]
+        public string? IpAddress { get; set; }
+    }
+}

--- a/edpicker-api/Models/Planner/Requests/PlannerRequests.cs
+++ b/edpicker-api/Models/Planner/Requests/PlannerRequests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace edpicker_api.Models.Planner.Requests
+{
+    public class TopicCompletionUpdateRequest
+    {
+        [Required]
+        public int InstanceId { get; set; }
+
+        [Required]
+        public bool IsCompleted { get; set; }
+    }
+
+    public class AssignTemplateRequest
+    {
+        [Required]
+        public int ClassId { get; set; }
+
+        [Required]
+        public int SectionId { get; set; }
+
+        [Required]
+        public int SubjectId { get; set; }
+
+        [Required]
+        public int TemplateId { get; set; }
+
+        [Required]
+        public int AcademicYearId { get; set; }
+    }
+
+    public class CreateCustomTemplateRequest
+    {
+        [Required]
+        public int SourceTemplateId { get; set; }
+
+        [Required]
+        [MaxLength(200)]
+        public string NewTemplateName { get; set; } = string.Empty;
+
+        public TemplateCustomizationRequest Customizations { get; set; } = new();
+    }
+
+    public class TemplateCustomizationRequest
+    {
+        public List<UnitCustomization> Units { get; set; } = new();
+    }
+
+    public class UnitCustomization
+    {
+        public string UnitName { get; set; } = string.Empty;
+        public int UnitOrder { get; set; }
+        public List<ChapterCustomization> Chapters { get; set; } = new();
+    }
+
+    public class ChapterCustomization
+    {
+        public string ChapterName { get; set; } = string.Empty;
+        public int ChapterOrder { get; set; }
+        public List<TopicCustomization> Topics { get; set; } = new();
+    }
+
+    public class TopicCustomization
+    {
+        public string TopicName { get; set; } = string.Empty;
+        public int TopicOrder { get; set; }
+    }
+
+    public class AcademicYearCreateRequest
+    {
+        [Required]
+        [MaxLength(50)]
+        public string YearName { get; set; } = string.Empty;
+
+        [Required]
+        public DateTime StartDate { get; set; }
+
+        [Required]
+        public DateTime EndDate { get; set; }
+    }
+
+    public class AcademicYearFreezeRequest
+    {
+        [Required]
+        public int AcademicYearId { get; set; }
+    }
+}

--- a/edpicker-api/Program.cs
+++ b/edpicker-api/Program.cs
@@ -26,6 +26,7 @@ try
     builder.Services.AddScoped<ISchoolAccountRepository, SchoolAccountRepository>();
     builder.Services.AddScoped<IJwtTokenService, JwtTokenService>();
     builder.Services.AddScoped<IQuestionPaperRepository, QuestionPaperRepository>();
+    builder.Services.AddScoped<IPlannerRepository, PlannerRepository>();
     builder.Services.AddControllers();
     builder.Services.AddDbContext<EdPickerDbContext>(options =>
         options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));

--- a/edpicker-api/Services/Interface/IPlannerRepository.cs
+++ b/edpicker-api/Services/Interface/IPlannerRepository.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using edpicker_api.Models.Planner.Dto;
+using edpicker_api.Models.Planner.Requests;
+
+namespace edpicker_api.Services.Interface
+{
+    public interface IPlannerRepository
+    {
+        Task<IReadOnlyList<ClassSummaryDto>> GetClassesAsync(CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<SectionSummaryDto>> GetSectionsByClassAsync(int classId, CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<SubjectSummaryDto>> GetSubjectsByClassAsync(int classId, CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<TemplateSummaryDto>> GetTemplatesAsync(int classId, int subjectId, CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<TemplateSummaryDto>> GetArchivedTemplatesAsync(CancellationToken cancellationToken = default);
+        Task<CurriculumInstanceDto?> GetCurriculumInstanceAsync(int instanceId, CancellationToken cancellationToken = default);
+        Task<CurriculumProgressDto?> GetProgressAsync(int instanceId, CancellationToken cancellationToken = default);
+        Task<CurriculumStructureDto?> GetCurriculumAsync(int instanceId, CancellationToken cancellationToken = default);
+        Task<TopicCompletionStatusDto> UpdateTopicCompletionAsync(int topicId, int instanceId, bool isCompleted, int? userId, string? ipAddress, CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<SectionProgressComparisonDto>> GetMultiSectionComparisonAsync(int classId, int subjectId, CancellationToken cancellationToken = default);
+        Task<PaginatedTopicsResponseDto> GetPaginatedTopicsAsync(int instanceId, int pageNumber, int pageSize, string? searchTerm, string filterStatus, CancellationToken cancellationToken = default);
+        Task<int> AssignTemplateAsync(AssignTemplateRequest request, int? userId, string? ipAddress, CancellationToken cancellationToken = default);
+        Task<TemplatePreviewDto?> GetTemplatePreviewAsync(int templateId, CancellationToken cancellationToken = default);
+        Task<int> CreateCustomTemplateAsync(CreateCustomTemplateRequest request, int? userId, string? ipAddress, CancellationToken cancellationToken = default);
+        Task<bool> ArchiveTemplateAsync(int templateId, int? userId, string? ipAddress, CancellationToken cancellationToken = default);
+        Task<bool> RestoreTemplateAsync(int templateId, int? userId, string? ipAddress, CancellationToken cancellationToken = default);
+        Task<IReadOnlyList<DataIntegrityIssueDto>> ValidateDataIntegrityAsync(CancellationToken cancellationToken = default);
+        Task<int> FixOrphanedRecordsAsync(CancellationToken cancellationToken = default);
+        Task<AcademicYearDto?> GetActiveAcademicYearAsync(CancellationToken cancellationToken = default);
+        Task<int> CreateAcademicYearAsync(string yearName, DateTime startDate, DateTime endDate, int? userId, string? ipAddress, CancellationToken cancellationToken = default);
+        Task<bool> FreezeAcademicYearAsync(int academicYearId, int? userId, string? ipAddress, CancellationToken cancellationToken = default);
+        Task<byte[]> ExportProgressAsync(int instanceId, CancellationToken cancellationToken = default);
+        Task<byte[]> ExportAuditTrailAsync(int instanceId, CancellationToken cancellationToken = default);
+    }
+}

--- a/edpicker-api/Services/PlannerRepository.cs
+++ b/edpicker-api/Services/PlannerRepository.cs
@@ -1,0 +1,1115 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using edpicker_api.Models.Planner.Dto;
+using edpicker_api.Models.Planner.Entities;
+using edpicker_api.Models.Planner.Requests;
+using edpicker_api.Services.Interface;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace edpicker_api.Services
+{
+    public class PlannerRepository : IPlannerRepository
+    {
+        private readonly EdPickerDbContext _context;
+        private readonly ILogger<PlannerRepository> _logger;
+
+        public PlannerRepository(EdPickerDbContext context, ILogger<PlannerRepository> logger)
+        {
+            _context = context;
+            _logger = logger;
+        }
+
+        public async Task<IReadOnlyList<ClassSummaryDto>> GetClassesAsync(CancellationToken cancellationToken = default)
+        {
+            return await _context.CurriculumClasses
+                .AsNoTracking()
+                .OrderBy(c => c.ClassName)
+                .Select(c => new ClassSummaryDto
+                {
+                    ClassId = c.ClassId,
+                    ClassName = c.ClassName
+                })
+                .ToListAsync(cancellationToken);
+        }
+
+        public async Task<IReadOnlyList<SectionSummaryDto>> GetSectionsByClassAsync(int classId, CancellationToken cancellationToken = default)
+        {
+            return await _context.Sections
+                .AsNoTracking()
+                .Where(s => s.ClassId == classId)
+                .OrderBy(s => s.SectionName)
+                .Select(s => new SectionSummaryDto
+                {
+                    SectionId = s.SectionId,
+                    SectionName = s.SectionName
+                })
+                .ToListAsync(cancellationToken);
+        }
+
+        public async Task<IReadOnlyList<SubjectSummaryDto>> GetSubjectsByClassAsync(int classId, CancellationToken cancellationToken = default)
+        {
+            return await _context.Subjects
+                .AsNoTracking()
+                .Where(s => s.ClassId == classId)
+                .OrderBy(s => s.SubjectName)
+                .Select(s => new SubjectSummaryDto
+                {
+                    SubjectId = s.SubjectId,
+                    SubjectName = s.SubjectName
+                })
+                .ToListAsync(cancellationToken);
+        }
+
+        public async Task<IReadOnlyList<TemplateSummaryDto>> GetTemplatesAsync(int classId, int subjectId, CancellationToken cancellationToken = default)
+        {
+            return await _context.Templates
+                .AsNoTracking()
+                .Where(t => t.ClassId == classId && t.SubjectId == subjectId)
+                .OrderBy(t => t.TemplateName)
+                .Select(t => new TemplateSummaryDto
+                {
+                    TemplateId = t.TemplateId,
+                    TemplateName = t.TemplateName,
+                    TemplateType = t.TemplateType,
+                    IsArchived = t.IsArchived,
+                    CreatedDate = t.CreatedDate
+                })
+                .ToListAsync(cancellationToken);
+        }
+
+        public async Task<IReadOnlyList<TemplateSummaryDto>> GetArchivedTemplatesAsync(CancellationToken cancellationToken = default)
+        {
+            return await _context.Templates
+                .AsNoTracking()
+                .Where(t => t.IsArchived)
+                .OrderByDescending(t => t.CreatedDate)
+                .Select(t => new TemplateSummaryDto
+                {
+                    TemplateId = t.TemplateId,
+                    TemplateName = t.TemplateName,
+                    TemplateType = t.TemplateType,
+                    IsArchived = t.IsArchived,
+                    CreatedDate = t.CreatedDate
+                })
+                .ToListAsync(cancellationToken);
+        }
+
+        public async Task<CurriculumInstanceDto?> GetCurriculumInstanceAsync(int instanceId, CancellationToken cancellationToken = default)
+        {
+            return await _context.CurriculumInstances
+                .AsNoTracking()
+                .Where(ci => ci.InstanceId == instanceId)
+                .Select(ci => new CurriculumInstanceDto
+                {
+                    InstanceId = ci.InstanceId,
+                    AcademicYearId = ci.AcademicYearId,
+                    ClassId = ci.ClassId,
+                    SectionId = ci.SectionId,
+                    SubjectId = ci.SubjectId,
+                    TemplateId = ci.TemplateId,
+                    AssignedDate = ci.AssignedDate,
+                    TemplateName = ci.Template.TemplateName
+                })
+                .FirstOrDefaultAsync(cancellationToken);
+        }
+
+        public async Task<CurriculumProgressDto?> GetProgressAsync(int instanceId, CancellationToken cancellationToken = default)
+        {
+            var instance = await _context.CurriculumInstances
+                .Include(ci => ci.Template)
+                .FirstOrDefaultAsync(ci => ci.InstanceId == instanceId, cancellationToken);
+
+            if (instance == null)
+            {
+                return null;
+            }
+
+            var query = _context.Topics
+                .AsNoTracking()
+                .Where(t => !t.IsArchived && !t.Chapter.IsArchived && !t.Chapter.Unit.IsArchived && t.Chapter.Unit.TemplateId == instance.TemplateId);
+
+            var totalTopics = await query.CountAsync(cancellationToken);
+
+            var completedQuery = _context.TopicCompletions
+                .AsNoTracking()
+                .Where(tc => tc.InstanceId == instanceId && tc.IsCompleted && !tc.Topic.IsArchived && !tc.Topic.Chapter.IsArchived && !tc.Topic.Chapter.Unit.IsArchived);
+
+            var completedTopics = await completedQuery.CountAsync(cancellationToken);
+
+            var lastUpdated = await completedQuery
+                .OrderByDescending(tc => tc.UpdatedDate)
+                .Select(tc => (DateTime?)tc.UpdatedDate)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            var percentage = totalTopics == 0 ? 0 : Math.Round((decimal)completedTopics / totalTopics * 100, 2);
+
+            return new CurriculumProgressDto
+            {
+                InstanceId = instance.InstanceId,
+                TotalTopics = totalTopics,
+                CompletedTopics = completedTopics,
+                Percentage = percentage,
+                TemplateName = instance.Template.TemplateName,
+                LastUpdated = lastUpdated
+            };
+        }
+
+        public async Task<CurriculumStructureDto?> GetCurriculumAsync(int instanceId, CancellationToken cancellationToken = default)
+        {
+            var instance = await _context.CurriculumInstances
+                .AsNoTracking()
+                .FirstOrDefaultAsync(ci => ci.InstanceId == instanceId, cancellationToken);
+
+            if (instance == null)
+            {
+                return null;
+            }
+
+            var completions = await _context.TopicCompletions
+                .AsNoTracking()
+                .Where(tc => tc.InstanceId == instanceId)
+                .ToDictionaryAsync(tc => tc.TopicId, tc => tc, cancellationToken);
+
+            var units = await _context.Units
+                .AsNoTracking()
+                .Where(u => u.TemplateId == instance.TemplateId && !u.IsArchived)
+                .OrderBy(u => u.UnitOrder)
+                .Select(u => new
+                {
+                    Unit = u,
+                    Chapters = u.Chapters
+                        .Where(c => !c.IsArchived)
+                        .OrderBy(c => c.ChapterOrder)
+                        .Select(c => new
+                        {
+                            Chapter = c,
+                            Topics = c.Topics
+                                .Where(t => !t.IsArchived)
+                                .OrderBy(t => t.TopicOrder)
+                                .ToList()
+                        })
+                        .ToList()
+                })
+                .ToListAsync(cancellationToken);
+
+            var result = new CurriculumStructureDto
+            {
+                InstanceId = instanceId
+            };
+
+            foreach (var unitData in units)
+            {
+                var unitDto = new CurriculumUnitDto
+                {
+                    UnitId = unitData.Unit.UnitId,
+                    UnitName = unitData.Unit.UnitName,
+                    UnitOrder = unitData.Unit.UnitOrder
+                };
+
+                foreach (var chapterData in unitData.Chapters)
+                {
+                    var chapterDto = new CurriculumChapterDto
+                    {
+                        ChapterId = chapterData.Chapter.ChapterId,
+                        ChapterName = chapterData.Chapter.ChapterName,
+                        ChapterOrder = chapterData.Chapter.ChapterOrder
+                    };
+
+                    foreach (var topic in chapterData.Topics)
+                    {
+                        completions.TryGetValue(topic.TopicId, out var completion);
+                        chapterDto.Topics.Add(new CurriculumTopicDto
+                        {
+                            TopicId = topic.TopicId,
+                            TopicName = topic.TopicName,
+                            TopicOrder = topic.TopicOrder,
+                            IsCompleted = completion?.IsCompleted ?? false,
+                            CompletedDate = completion?.CompletedDate
+                        });
+                    }
+
+                    unitDto.Chapters.Add(chapterDto);
+                }
+
+                result.Units.Add(unitDto);
+            }
+
+            return result;
+        }
+
+        public async Task<TopicCompletionStatusDto> UpdateTopicCompletionAsync(int topicId, int instanceId, bool isCompleted, int? userId, string? ipAddress, CancellationToken cancellationToken = default)
+        {
+            var topic = await _context.Topics
+                .Include(t => t.Chapter)
+                .ThenInclude(c => c.Unit)
+                .FirstOrDefaultAsync(t => t.TopicId == topicId, cancellationToken);
+
+            if (topic == null)
+            {
+                throw new KeyNotFoundException($"Topic {topicId} not found");
+            }
+
+            var instance = await _context.CurriculumInstances
+                .FirstOrDefaultAsync(ci => ci.InstanceId == instanceId, cancellationToken);
+
+            if (instance == null)
+            {
+                throw new KeyNotFoundException($"Curriculum instance {instanceId} not found");
+            }
+
+            if (topic.Chapter.Unit.TemplateId != instance.TemplateId)
+            {
+                throw new InvalidOperationException("Topic does not belong to the specified curriculum instance");
+            }
+
+            var completion = await _context.TopicCompletions
+                .FirstOrDefaultAsync(tc => tc.InstanceId == instanceId && tc.TopicId == topicId, cancellationToken);
+
+            var now = DateTime.UtcNow;
+
+            if (completion != null)
+            {
+                if (completion.IsCompleted == isCompleted)
+                {
+                    _logger.LogInformation("Topic completion skipped (debounced). TopicId: {TopicId}, InstanceId: {InstanceId}", topicId, instanceId);
+                    return new TopicCompletionStatusDto
+                    {
+                        TopicId = topicId,
+                        InstanceId = instanceId,
+                        IsCompleted = completion.IsCompleted,
+                        CompletedDate = completion.CompletedDate,
+                        UpdatedDate = completion.UpdatedDate
+                    };
+                }
+
+                var oldValue = JsonSerializer.Serialize(completion);
+
+                completion.IsCompleted = isCompleted;
+                completion.CompletedDate = isCompleted ? now : null;
+                completion.UpdatedDate = now;
+                completion.UpdatedBy = userId;
+
+                await _context.SaveChangesAsync(cancellationToken);
+
+                await LogAuditAsync("TopicCompletion", completion.CompletionId, "UPDATE", oldValue, JsonSerializer.Serialize(completion), userId, ipAddress, cancellationToken);
+
+                return new TopicCompletionStatusDto
+                {
+                    TopicId = topicId,
+                    InstanceId = instanceId,
+                    IsCompleted = completion.IsCompleted,
+                    CompletedDate = completion.CompletedDate,
+                    UpdatedDate = completion.UpdatedDate
+                };
+            }
+            else
+            {
+                var newCompletion = new TopicCompletion
+                {
+                    InstanceId = instanceId,
+                    TopicId = topicId,
+                    IsCompleted = isCompleted,
+                    CompletedDate = isCompleted ? now : null,
+                    UpdatedDate = now,
+                    UpdatedBy = userId
+                };
+
+                _context.TopicCompletions.Add(newCompletion);
+                await _context.SaveChangesAsync(cancellationToken);
+
+                await LogAuditAsync("TopicCompletion", newCompletion.CompletionId, "INSERT", null, JsonSerializer.Serialize(newCompletion), userId, ipAddress, cancellationToken);
+
+                return new TopicCompletionStatusDto
+                {
+                    TopicId = topicId,
+                    InstanceId = instanceId,
+                    IsCompleted = newCompletion.IsCompleted,
+                    CompletedDate = newCompletion.CompletedDate,
+                    UpdatedDate = newCompletion.UpdatedDate
+                };
+            }
+        }
+
+        public async Task<IReadOnlyList<SectionProgressComparisonDto>> GetMultiSectionComparisonAsync(int classId, int subjectId, CancellationToken cancellationToken = default)
+        {
+            var sections = await _context.Sections
+                .AsNoTracking()
+                .Where(s => s.ClassId == classId)
+                .OrderBy(s => s.SectionName)
+                .ToListAsync(cancellationToken);
+
+            var activeYear = await _context.AcademicYears
+                .AsNoTracking()
+                .OrderByDescending(y => y.IsActive)
+                .ThenByDescending(y => y.StartDate)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            var instances = await _context.CurriculumInstances
+                .AsNoTracking()
+                .Where(ci => ci.ClassId == classId && ci.SubjectId == subjectId && (activeYear == null || ci.AcademicYearId == activeYear.AcademicYearId))
+                .ToListAsync(cancellationToken);
+
+            var instanceIds = instances.Select(ci => ci.InstanceId).ToList();
+            var templateIds = instances.Select(ci => ci.TemplateId).Distinct().ToList();
+
+            var templateNames = await _context.Templates
+                .AsNoTracking()
+                .Where(t => templateIds.Contains(t.TemplateId))
+                .ToDictionaryAsync(t => t.TemplateId, t => t.TemplateName, cancellationToken);
+
+            var completions = await _context.TopicCompletions
+                .AsNoTracking()
+                .Where(tc => instanceIds.Contains(tc.InstanceId) && tc.IsCompleted)
+                .GroupBy(tc => tc.InstanceId)
+                .Select(g => new { InstanceId = g.Key, Count = g.Count(), LastUpdated = g.Max(tc => tc.UpdatedDate) })
+                .ToListAsync(cancellationToken);
+
+            var completionLookup = completions.ToDictionary(c => c.InstanceId, c => c);
+
+            var templateTopicCounts = await _context.Topics
+                .AsNoTracking()
+                .Where(t => templateIds.Contains(t.Chapter.Unit.TemplateId) && !t.IsArchived && !t.Chapter.IsArchived && !t.Chapter.Unit.IsArchived)
+                .GroupBy(t => t.Chapter.Unit.TemplateId)
+                .Select(g => new { TemplateId = g.Key, Count = g.Count() })
+                .ToListAsync(cancellationToken);
+
+            var topicCountLookup = templateTopicCounts.ToDictionary(t => t.TemplateId, t => t.Count);
+
+            var result = new List<SectionProgressComparisonDto>();
+
+            foreach (var section in sections)
+            {
+                var instance = instances.FirstOrDefault(ci => ci.SectionId == section.SectionId);
+
+                if (instance == null)
+                {
+                    result.Add(new SectionProgressComparisonDto
+                    {
+                        SectionId = section.SectionId,
+                        SectionName = section.SectionName,
+                        TemplateName = string.Empty,
+                        InstanceId = null,
+                        TotalTopics = 0,
+                        CompletedTopics = 0,
+                        Percentage = 0,
+                        LastUpdated = null
+                    });
+                    continue;
+                }
+
+                completionLookup.TryGetValue(instance.InstanceId, out var completionData);
+                topicCountLookup.TryGetValue(instance.TemplateId, out var totalTopics);
+                templateNames.TryGetValue(instance.TemplateId, out var templateName);
+
+                var completedCount = completionData?.Count ?? 0;
+                var totalCount = totalTopics;
+                var percentage = totalCount.GetValueOrDefault() == 0 ? 0 : Math.Round((decimal)completedCount / totalCount.Value * 100, 2);
+
+                result.Add(new SectionProgressComparisonDto
+                {
+                    SectionId = section.SectionId,
+                    SectionName = section.SectionName,
+                    TemplateName = templateName ?? string.Empty,
+                    InstanceId = instance.InstanceId,
+                    TotalTopics = totalCount ?? 0,
+                    CompletedTopics = completedCount,
+                    Percentage = percentage,
+                    LastUpdated = completionData?.LastUpdated
+                });
+            }
+
+            return result;
+        }
+
+        public async Task<PaginatedTopicsResponseDto> GetPaginatedTopicsAsync(int instanceId, int pageNumber, int pageSize, string? searchTerm, string filterStatus, CancellationToken cancellationToken = default)
+        {
+            if (pageNumber <= 0)
+            {
+                pageNumber = 1;
+            }
+
+            if (pageSize <= 0)
+            {
+                pageSize = 20;
+            }
+
+            pageSize = Math.Min(pageSize, 100);
+
+            var instance = await _context.CurriculumInstances
+                .AsNoTracking()
+                .FirstOrDefaultAsync(ci => ci.InstanceId == instanceId, cancellationToken);
+
+            if (instance == null)
+            {
+                throw new KeyNotFoundException($"Curriculum instance {instanceId} not found");
+            }
+
+            var topicsQuery = _context.Topics
+                .AsNoTracking()
+                .Where(t => t.Chapter.Unit.TemplateId == instance.TemplateId && !t.IsArchived && !t.Chapter.IsArchived && !t.Chapter.Unit.IsArchived);
+
+            if (!string.IsNullOrWhiteSpace(searchTerm))
+            {
+                topicsQuery = topicsQuery.Where(t => t.TopicName.Contains(searchTerm));
+            }
+
+            filterStatus = filterStatus?.ToLowerInvariant() ?? "all";
+
+            if (filterStatus == "completed")
+            {
+                topicsQuery = topicsQuery.Where(t => _context.TopicCompletions.Any(tc => tc.InstanceId == instanceId && tc.TopicId == t.TopicId && tc.IsCompleted));
+            }
+            else if (filterStatus == "incomplete")
+            {
+                topicsQuery = topicsQuery.Where(t => !_context.TopicCompletions.Any(tc => tc.InstanceId == instanceId && tc.TopicId == t.TopicId && tc.IsCompleted));
+            }
+
+            var totalCount = await topicsQuery.CountAsync(cancellationToken);
+            var completionMap = await _context.TopicCompletions
+                .AsNoTracking()
+                .Where(tc => tc.InstanceId == instanceId)
+                .ToDictionaryAsync(tc => tc.TopicId, tc => tc, cancellationToken);
+
+            var topicEntities = await topicsQuery
+                .OrderBy(t => t.TopicOrder)
+                .Skip((pageNumber - 1) * pageSize)
+                .Take(pageSize)
+                .Select(t => new
+                {
+                    t.TopicId,
+                    t.TopicName,
+                    t.TopicOrder
+                })
+                .ToListAsync(cancellationToken);
+
+            var topics = topicEntities
+                .Select(t =>
+                {
+                    completionMap.TryGetValue(t.TopicId, out var completion);
+                    return new CurriculumTopicDto
+                    {
+                        TopicId = t.TopicId,
+                        TopicName = t.TopicName,
+                        TopicOrder = t.TopicOrder,
+                        IsCompleted = completion?.IsCompleted ?? false,
+                        CompletedDate = completion?.CompletedDate
+                    };
+                })
+                .ToList();
+
+            var totalPages = (int)Math.Ceiling(totalCount / (double)pageSize);
+
+            return new PaginatedTopicsResponseDto
+            {
+                Topics = topics,
+                TotalCount = totalCount,
+                PageNumber = pageNumber,
+                PageSize = pageSize,
+                TotalPages = totalPages
+            };
+        }
+
+        public async Task<int> AssignTemplateAsync(AssignTemplateRequest request, int? userId, string? ipAddress, CancellationToken cancellationToken = default)
+        {
+            var template = await _context.Templates
+                .AsNoTracking()
+                .FirstOrDefaultAsync(t => t.TemplateId == request.TemplateId, cancellationToken);
+
+            if (template == null)
+            {
+                throw new KeyNotFoundException($"Template {request.TemplateId} not found");
+            }
+
+            if (template.ClassId != request.ClassId || template.SubjectId != request.SubjectId)
+            {
+                throw new InvalidOperationException("Template is not compatible with the selected class or subject");
+            }
+
+            var existing = await _context.CurriculumInstances
+                .FirstOrDefaultAsync(ci => ci.AcademicYearId == request.AcademicYearId && ci.ClassId == request.ClassId && ci.SectionId == request.SectionId && ci.SubjectId == request.SubjectId, cancellationToken);
+
+            if (existing != null)
+            {
+                throw new InvalidOperationException("Template already assigned to this class-section-subject for the academic year");
+            }
+
+            using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+
+            try
+            {
+                var instance = new CurriculumInstance
+                {
+                    AcademicYearId = request.AcademicYearId,
+                    ClassId = request.ClassId,
+                    SectionId = request.SectionId,
+                    SubjectId = request.SubjectId,
+                    TemplateId = request.TemplateId,
+                    AssignedDate = DateTime.UtcNow
+                };
+
+                _context.CurriculumInstances.Add(instance);
+                await _context.SaveChangesAsync(cancellationToken);
+
+                await LogAuditAsync("CurriculumInstance", instance.InstanceId, "INSERT", null, JsonSerializer.Serialize(instance), userId, ipAddress, cancellationToken);
+
+                await transaction.CommitAsync(cancellationToken);
+
+                return instance.InstanceId;
+            }
+            catch
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                throw;
+            }
+        }
+
+        public async Task<TemplatePreviewDto?> GetTemplatePreviewAsync(int templateId, CancellationToken cancellationToken = default)
+        {
+            var template = await _context.Templates
+                .AsNoTracking()
+                .FirstOrDefaultAsync(t => t.TemplateId == templateId, cancellationToken);
+
+            if (template == null)
+            {
+                return null;
+            }
+
+            var units = await _context.Units
+                .AsNoTracking()
+                .Where(u => u.TemplateId == templateId && !u.IsArchived)
+                .OrderBy(u => u.UnitOrder)
+                .ToListAsync(cancellationToken);
+
+            var chapters = await _context.Chapters
+                .AsNoTracking()
+                .Where(c => units.Select(u => u.UnitId).Contains(c.UnitId) && !c.IsArchived)
+                .OrderBy(c => c.ChapterOrder)
+                .ToListAsync(cancellationToken);
+
+            var topics = await _context.Topics
+                .AsNoTracking()
+                .Where(t => chapters.Select(c => c.ChapterId).Contains(t.ChapterId) && !t.IsArchived)
+                .OrderBy(t => t.TopicOrder)
+                .ToListAsync(cancellationToken);
+
+            return new TemplatePreviewDto
+            {
+                TemplateId = template.TemplateId,
+                TemplateName = template.TemplateName,
+                UnitCount = units.Count,
+                ChapterCount = chapters.Count,
+                TopicCount = topics.Count,
+                UnitNames = units.Select(u => u.UnitName).ToList(),
+                ChapterNames = chapters.Select(c => c.ChapterName).ToList(),
+                TopicNames = topics.Select(t => t.TopicName).Take(100).ToList()
+            };
+        }
+
+        public async Task<int> CreateCustomTemplateAsync(CreateCustomTemplateRequest request, int? userId, string? ipAddress, CancellationToken cancellationToken = default)
+        {
+            var sourceTemplate = await _context.Templates
+                .Include(t => t.Units)
+                    .ThenInclude(u => u.Chapters)
+                        .ThenInclude(c => c.Topics)
+                .FirstOrDefaultAsync(t => t.TemplateId == request.SourceTemplateId, cancellationToken);
+
+            if (sourceTemplate == null)
+            {
+                throw new KeyNotFoundException($"Source template {request.SourceTemplateId} not found");
+            }
+
+            using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+
+            try
+            {
+                var newTemplate = new Template
+                {
+                    ClassId = sourceTemplate.ClassId,
+                    SubjectId = sourceTemplate.SubjectId,
+                    TemplateName = request.NewTemplateName,
+                    TemplateType = "Custom",
+                    SourceTemplateId = sourceTemplate.TemplateId,
+                    CreatedDate = DateTime.UtcNow,
+                    CreatedBy = userId,
+                    IsArchived = false
+                };
+
+                _context.Templates.Add(newTemplate);
+                await _context.SaveChangesAsync(cancellationToken);
+
+                if (request.Customizations?.Units != null && request.Customizations.Units.Any())
+                {
+                    foreach (var unitCustomization in request.Customizations.Units.OrderBy(u => u.UnitOrder))
+                    {
+                        var unit = new Unit
+                        {
+                            TemplateId = newTemplate.TemplateId,
+                            UnitName = unitCustomization.UnitName,
+                            UnitOrder = unitCustomization.UnitOrder,
+                            CreatedDate = DateTime.UtcNow,
+                            IsArchived = false
+                        };
+
+                        _context.Units.Add(unit);
+                        await _context.SaveChangesAsync(cancellationToken);
+
+                        foreach (var chapterCustomization in unitCustomization.Chapters.OrderBy(c => c.ChapterOrder))
+                        {
+                            var chapter = new Chapter
+                            {
+                                UnitId = unit.UnitId,
+                                ChapterName = chapterCustomization.ChapterName,
+                                ChapterOrder = chapterCustomization.ChapterOrder,
+                                CreatedDate = DateTime.UtcNow,
+                                IsArchived = false
+                            };
+
+                            _context.Chapters.Add(chapter);
+                            await _context.SaveChangesAsync(cancellationToken);
+
+                            foreach (var topicCustomization in chapterCustomization.Topics.OrderBy(t => t.TopicOrder))
+                            {
+                                var topic = new Topic
+                                {
+                                    ChapterId = chapter.ChapterId,
+                                    TopicName = topicCustomization.TopicName,
+                                    TopicOrder = topicCustomization.TopicOrder,
+                                    CreatedDate = DateTime.UtcNow,
+                                    IsArchived = false
+                                };
+
+                                _context.Topics.Add(topic);
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    foreach (var unit in sourceTemplate.Units.OrderBy(u => u.UnitOrder))
+                    {
+                        var clonedUnit = new Unit
+                        {
+                            TemplateId = newTemplate.TemplateId,
+                            UnitName = unit.UnitName,
+                            UnitOrder = unit.UnitOrder,
+                            CreatedDate = DateTime.UtcNow,
+                            IsArchived = false
+                        };
+
+                        _context.Units.Add(clonedUnit);
+                        await _context.SaveChangesAsync(cancellationToken);
+
+                        foreach (var chapter in unit.Chapters.OrderBy(c => c.ChapterOrder))
+                        {
+                            var clonedChapter = new Chapter
+                            {
+                                UnitId = clonedUnit.UnitId,
+                                ChapterName = chapter.ChapterName,
+                                ChapterOrder = chapter.ChapterOrder,
+                                CreatedDate = DateTime.UtcNow,
+                                IsArchived = false
+                            };
+
+                            _context.Chapters.Add(clonedChapter);
+                            await _context.SaveChangesAsync(cancellationToken);
+
+                            foreach (var topic in chapter.Topics.OrderBy(t => t.TopicOrder))
+                            {
+                                var clonedTopic = new Topic
+                                {
+                                    ChapterId = clonedChapter.ChapterId,
+                                    TopicName = topic.TopicName,
+                                    TopicOrder = topic.TopicOrder,
+                                    CreatedDate = DateTime.UtcNow,
+                                    IsArchived = false
+                                };
+
+                                _context.Topics.Add(clonedTopic);
+                            }
+                        }
+                    }
+                }
+
+                await _context.SaveChangesAsync(cancellationToken);
+
+                await LogAuditAsync("Template", newTemplate.TemplateId, "INSERT", null, JsonSerializer.Serialize(newTemplate), userId, ipAddress, cancellationToken);
+
+                await transaction.CommitAsync(cancellationToken);
+
+                return newTemplate.TemplateId;
+            }
+            catch
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                throw;
+            }
+        }
+
+        public async Task<bool> ArchiveTemplateAsync(int templateId, int? userId, string? ipAddress, CancellationToken cancellationToken = default)
+        {
+            var template = await _context.Templates
+                .Include(t => t.Units)
+                    .ThenInclude(u => u.Chapters)
+                        .ThenInclude(c => c.Topics)
+                .FirstOrDefaultAsync(t => t.TemplateId == templateId, cancellationToken);
+
+            if (template == null)
+            {
+                throw new KeyNotFoundException($"Template {templateId} not found");
+            }
+
+            var inUse = await _context.CurriculumInstances
+                .AnyAsync(ci => ci.TemplateId == templateId, cancellationToken);
+
+            if (inUse)
+            {
+                throw new InvalidOperationException("Cannot archive template while it is assigned to active curriculum instances");
+            }
+
+            if (template.IsArchived)
+            {
+                return false;
+            }
+
+            using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+
+            try
+            {
+                template.IsArchived = true;
+
+                foreach (var unit in template.Units)
+                {
+                    unit.IsArchived = true;
+                    foreach (var chapter in unit.Chapters)
+                    {
+                        chapter.IsArchived = true;
+                        foreach (var topic in chapter.Topics)
+                        {
+                            topic.IsArchived = true;
+                        }
+                    }
+                }
+
+                await _context.SaveChangesAsync(cancellationToken);
+
+                await LogAuditAsync("Template", template.TemplateId, "ARCHIVE", null, JsonSerializer.Serialize(template), userId, ipAddress, cancellationToken);
+
+                await transaction.CommitAsync(cancellationToken);
+
+                return true;
+            }
+            catch
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                throw;
+            }
+        }
+
+        public async Task<bool> RestoreTemplateAsync(int templateId, int? userId, string? ipAddress, CancellationToken cancellationToken = default)
+        {
+            var template = await _context.Templates
+                .Include(t => t.Units)
+                    .ThenInclude(u => u.Chapters)
+                        .ThenInclude(c => c.Topics)
+                .FirstOrDefaultAsync(t => t.TemplateId == templateId, cancellationToken);
+
+            if (template == null)
+            {
+                throw new KeyNotFoundException($"Template {templateId} not found");
+            }
+
+            if (!template.IsArchived)
+            {
+                return false;
+            }
+
+            using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+
+            try
+            {
+                template.IsArchived = false;
+
+                foreach (var unit in template.Units)
+                {
+                    unit.IsArchived = false;
+                    foreach (var chapter in unit.Chapters)
+                    {
+                        chapter.IsArchived = false;
+                        foreach (var topic in chapter.Topics)
+                        {
+                            topic.IsArchived = false;
+                        }
+                    }
+                }
+
+                await _context.SaveChangesAsync(cancellationToken);
+
+                await LogAuditAsync("Template", template.TemplateId, "RESTORE", null, JsonSerializer.Serialize(template), userId, ipAddress, cancellationToken);
+
+                await transaction.CommitAsync(cancellationToken);
+
+                return true;
+            }
+            catch
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                throw;
+            }
+        }
+
+        public async Task<IReadOnlyList<DataIntegrityIssueDto>> ValidateDataIntegrityAsync(CancellationToken cancellationToken = default)
+        {
+            var issues = new List<DataIntegrityIssueDto>();
+
+            var orphanedTopics = await _context.Topics
+                .AsNoTracking()
+                .Where(t => !_context.Chapters.Any(c => c.ChapterId == t.ChapterId))
+                .Select(t => t.TopicId)
+                .ToListAsync(cancellationToken);
+
+            if (orphanedTopics.Any())
+            {
+                issues.Add(new DataIntegrityIssueDto
+                {
+                    IssueType = "OrphanedTopics",
+                    Description = $"Topics without chapters: {string.Join(", ", orphanedTopics.Take(20))}"
+                });
+            }
+
+            var orphanedChapters = await _context.Chapters
+                .AsNoTracking()
+                .Where(c => !_context.Units.Any(u => u.UnitId == c.UnitId))
+                .Select(c => c.ChapterId)
+                .ToListAsync(cancellationToken);
+
+            if (orphanedChapters.Any())
+            {
+                issues.Add(new DataIntegrityIssueDto
+                {
+                    IssueType = "OrphanedChapters",
+                    Description = $"Chapters without units: {string.Join(", ", orphanedChapters.Take(20))}"
+                });
+            }
+
+            var orphanedUnits = await _context.Units
+                .AsNoTracking()
+                .Where(u => !_context.Templates.Any(t => t.TemplateId == u.TemplateId))
+                .Select(u => u.UnitId)
+                .ToListAsync(cancellationToken);
+
+            if (orphanedUnits.Any())
+            {
+                issues.Add(new DataIntegrityIssueDto
+                {
+                    IssueType = "OrphanedUnits",
+                    Description = $"Units without templates: {string.Join(", ", orphanedUnits.Take(20))}"
+                });
+            }
+
+            var invalidCompletions = await _context.TopicCompletions
+                .AsNoTracking()
+                .Where(tc => !_context.Topics.Any(t => t.TopicId == tc.TopicId))
+                .Select(tc => tc.CompletionId)
+                .ToListAsync(cancellationToken);
+
+            if (invalidCompletions.Any())
+            {
+                issues.Add(new DataIntegrityIssueDto
+                {
+                    IssueType = "InvalidCompletions",
+                    Description = $"Completion records referencing missing topics: {string.Join(", ", invalidCompletions.Take(20))}"
+                });
+            }
+
+            return issues;
+        }
+
+        public async Task<int> FixOrphanedRecordsAsync(CancellationToken cancellationToken = default)
+        {
+            var orphanedCompletionIds = await _context.TopicCompletions
+                .Where(tc => !_context.Topics.Any(t => t.TopicId == tc.TopicId))
+                .Select(tc => tc.CompletionId)
+                .ToListAsync(cancellationToken);
+
+            if (!orphanedCompletionIds.Any())
+            {
+                return 0;
+            }
+
+            var completions = await _context.TopicCompletions
+                .Where(tc => orphanedCompletionIds.Contains(tc.CompletionId))
+                .ToListAsync(cancellationToken);
+
+            _context.TopicCompletions.RemoveRange(completions);
+            await _context.SaveChangesAsync(cancellationToken);
+
+            return completions.Count;
+        }
+
+        public async Task<AcademicYearDto?> GetActiveAcademicYearAsync(CancellationToken cancellationToken = default)
+        {
+            return await _context.AcademicYears
+                .AsNoTracking()
+                .Where(y => y.IsActive)
+                .OrderByDescending(y => y.StartDate)
+                .Select(y => new AcademicYearDto
+                {
+                    AcademicYearId = y.AcademicYearId,
+                    YearName = y.YearName,
+                    StartDate = y.StartDate,
+                    EndDate = y.EndDate,
+                    IsActive = y.IsActive,
+                    IsFrozen = y.IsFrozen
+                })
+                .FirstOrDefaultAsync(cancellationToken);
+        }
+
+        public async Task<int> CreateAcademicYearAsync(string yearName, DateTime startDate, DateTime endDate, int? userId, string? ipAddress, CancellationToken cancellationToken = default)
+        {
+            if (endDate <= startDate)
+            {
+                throw new InvalidOperationException("Academic year end date must be after start date");
+            }
+
+            using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+
+            try
+            {
+                var existingActiveYears = await _context.AcademicYears.Where(y => y.IsActive).ToListAsync(cancellationToken);
+                foreach (var year in existingActiveYears)
+                {
+                    year.IsActive = false;
+                }
+
+                var newYear = new AcademicYear
+                {
+                    YearName = yearName,
+                    StartDate = startDate,
+                    EndDate = endDate,
+                    IsActive = true,
+                    IsFrozen = false
+                };
+
+                _context.AcademicYears.Add(newYear);
+                await _context.SaveChangesAsync(cancellationToken);
+
+                await LogAuditAsync("AcademicYear", newYear.AcademicYearId, "INSERT", null, JsonSerializer.Serialize(newYear), userId, ipAddress, cancellationToken);
+
+                await transaction.CommitAsync(cancellationToken);
+
+                return newYear.AcademicYearId;
+            }
+            catch
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                throw;
+            }
+        }
+
+        public async Task<bool> FreezeAcademicYearAsync(int academicYearId, int? userId, string? ipAddress, CancellationToken cancellationToken = default)
+        {
+            var year = await _context.AcademicYears.FirstOrDefaultAsync(y => y.AcademicYearId == academicYearId, cancellationToken);
+
+            if (year == null)
+            {
+                throw new KeyNotFoundException($"Academic year {academicYearId} not found");
+            }
+
+            if (year.IsFrozen)
+            {
+                return false;
+            }
+
+            year.IsFrozen = true;
+            await _context.SaveChangesAsync(cancellationToken);
+
+            await LogAuditAsync("AcademicYear", year.AcademicYearId, "FREEZE", null, JsonSerializer.Serialize(year), userId, ipAddress, cancellationToken);
+
+            return true;
+        }
+
+        public async Task<byte[]> ExportProgressAsync(int instanceId, CancellationToken cancellationToken = default)
+        {
+            var curriculum = await GetCurriculumAsync(instanceId, cancellationToken);
+            if (curriculum == null)
+            {
+                throw new KeyNotFoundException($"Curriculum instance {instanceId} not found");
+            }
+
+            var lines = new List<string> { "Unit,Chapter,Topic,IsCompleted,CompletedDate" };
+            foreach (var unit in curriculum.Units)
+            {
+                foreach (var chapter in unit.Chapters)
+                {
+                    foreach (var topic in chapter.Topics)
+                    {
+                        lines.Add($"{Escape(unit.UnitName)},{Escape(chapter.ChapterName)},{Escape(topic.TopicName)},{topic.IsCompleted},{topic.CompletedDate:O}");
+                    }
+                }
+            }
+
+            return Encoding.UTF8.GetBytes(string.Join("\n", lines));
+        }
+
+        public async Task<byte[]> ExportAuditTrailAsync(int instanceId, CancellationToken cancellationToken = default)
+        {
+            var completionIds = await _context.TopicCompletions
+                .Where(tc => tc.InstanceId == instanceId)
+                .Select(tc => tc.CompletionId)
+                .ToListAsync(cancellationToken);
+
+            if (!completionIds.Any())
+            {
+                return Array.Empty<byte>();
+            }
+
+            var completionIdsLong = completionIds.Select(id => (long)id).ToList();
+
+            var logs = await _context.AuditLogs
+                .AsNoTracking()
+                .Where(a => a.TableName == "TopicCompletion" && completionIdsLong.Contains(a.RecordId))
+                .OrderBy(a => a.UpdatedDate)
+                .ToListAsync(cancellationToken);
+
+            var lines = new List<string> { "AuditId,TableName,RecordId,Action,UpdatedDate,UpdatedBy,IpAddress" };
+            lines.AddRange(logs.Select(l => $"{l.AuditId},{Escape(l.TableName)},{l.RecordId},{Escape(l.Action)},{l.UpdatedDate:O},{l.UpdatedBy},{Escape(l.IpAddress ?? string.Empty)}"));
+
+            return Encoding.UTF8.GetBytes(string.Join("\n", lines));
+        }
+
+        private static string Escape(string value)
+        {
+            if (value.Contains(',') || value.Contains('"'))
+            {
+                var escaped = value.Replace("\"", "\"\"");
+                return $"\"{escaped}\"";
+            }
+
+            return value;
+        }
+
+        private async Task LogAuditAsync(string tableName, long recordId, string action, string? oldValue, string? newValue, int? userId, string? ipAddress, CancellationToken cancellationToken)
+        {
+            var log = new AuditLog
+            {
+                TableName = tableName,
+                RecordId = recordId,
+                Action = action,
+                OldValue = oldValue,
+                NewValue = newValue,
+                UpdatedDate = DateTime.UtcNow,
+                UpdatedBy = userId,
+                IpAddress = ipAddress
+            };
+
+            _context.AuditLogs.Add(log);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add comprehensive PlannerController following repository-driven architecture for curriculum management endpoints
- introduce planner domain entities, DTOs, and request models covering curriculum, templates, progress, and academic year workflows
- implement PlannerRepository with EF Core operations, export utilities, integrity validation, and register repository in DI container

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da2284cc68832abdacf860a63bdd73