### PR TITLE
Add celebration module backend implementation

### DIFF
--- a/docs/celebration-dashboard/API-Spec.md
+++ b/docs/celebration-dashboard/API-Spec.md
@@ -1,0 +1,162 @@
+# Celebration API Specification
+
+## Base Configuration
+- **Namespace**: `EdPicker.Api.Controllers`
+- **Controller**: `CelebrationController : BaseApiController`
+- **Route Prefix**: `/api/celebration`
+- **Authentication**: `[Authorize(Roles = Roles.Principal)]`
+- **Versioning**: Align with existing `ApiVersion("1.0")` attribute pattern.
+- **Dependencies**:
+  - `ICelebrationProfileService`
+  - `ICelebrationDashboardService`
+  - `ICelebrationSmsService`
+  - `ICelebrationAuditService`
+  - `IHttpContextAccessor` for AdminId resolution.
+
+## Endpoints
+
+### POST `/profiles/upload`
+Imports bulk profiles from CSV or Excel.
+
+- **Request**: `multipart/form-data` with `file` field.
+- **Validation**:
+  - MIME types: `text/csv`, `application/vnd.ms-excel`, `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`.
+  - Mandatory columns: `Type,Name,DOB,Anniversary,Phone,Consent` (case-insensitive).
+- **Processing**:
+  - Parse using `ICelebrationImportParser` (NgxCsvParser counterpart on UI).
+  - Deduplicate only by composite `(Type, Name, DOB, Phone)` within the upload batch.
+  - Persist via `ProfilesService.UpsertRangeAsync` with transactional scope.
+  - Append audit trail entry with details count and filename.
+- **Response**:
+```json
+{
+  "success": true,
+  "payload": {
+    "imported": 150,
+    "errors": ["Row 5: Invalid DOB"]
+  }
+}
+```
+
+### POST `/profiles/students`
+Create or update a student profile.
+
+- **Body**:
+```json
+{
+  "studentId": 0,
+  "name": "Rahul Kumar",
+  "dob": "2008-09-29",
+  "phone": "+919876543210",
+  "consent": true
+}
+```
+- **Rules**:
+  - `studentId` optional; when >0 triggers update with optimistic concurrency (timestamp).
+  - Validate phone format, DOB (past date), consent default true.
+- **Response**: `{ "success": true, "payload": { "studentId": 42 } }`
+
+### POST `/profiles/teachers`
+Analogous to students with additional nullable `anniversary`.
+
+### GET `/dashboard/today`
+Return aggregated data for the current date.
+
+- **Query Params**: none.
+- **Behavior**:
+  - Teachers: join latest SMS status from `CelebrationLogs` when available, otherwise mark as `Pending`.
+  - Students: return count and optional preview list (first 50 items when requested via `includeStudents=true`).
+  - Delivery summary derived from logs within the current day window (IST midnight to 23:59:59).
+- **Response**:
+```json
+{
+  "success": true,
+  "payload": {
+    "teachers": [
+      {
+        "teacherId": 3,
+        "name": "Anita Sharma",
+        "eventType": "Anniversary",
+        "phone": "+919812345678",
+        "status": "Delivered",
+        "sentAt": "2025-09-29T09:05:12+05:30"
+      }
+    ],
+    "students": {
+      "count": 125,
+      "preview": []
+    },
+    "summary": {
+      "totalEvents": 150,
+      "delivered": 147,
+      "failed": 3
+    },
+    "alerts": {
+      "failedCount": 3
+    }
+  }
+}
+```
+
+### GET `/dashboard/history`
+Fetch paginated logs for a specific date range.
+
+- **Query**: `date=yyyy-MM-dd` (default today), `status`, `page`, `pageSize` (default 1, 50).
+- **Response** includes total count for client pagination.
+
+### POST `/sms/test`
+Manual test SMS (non-production safeguard).
+- Restricted to development environment via feature flag.
+- Logs to audit trail with reason `Send` and `Details` referencing manual trigger.
+
+### POST `/webhook/optout`
+Processes STOP replies from MSG91.
+
+- **Body**:
+```json
+{
+  "phone": "+919812345678",
+  "message": "STOP"
+}
+```
+- **Behavior**:
+  - Normalize phone.
+  - Set `Consent=false` across Students and Teachers with matching phone.
+  - Append audit entry `Action=OptOut`.
+  - Respond with `{ "success": true, "payload": { "updated": true } }`.
+
+### POST `/config/school`
+Persist the SMS personalization name.
+
+- **Body**: `{ "schoolName": "Springfield High" }`
+- **Validation**: 4–100 characters.
+- **Response**: `{ "success": true }`
+
+## Background Jobs
+- Register Hangfire recurring job `CelebrationService.SendDailyReminders` with cron `"30 3 * * *"` (UTC aligning with 9:00 AM IST).
+- `SendDailyReminders` pipeline:
+  1. Query eligible students/teachers (consent true, DOB/Anniversary matches date).
+  2. Enqueue per-recipient job to respect 100/hour throughput; use Hangfire batches or Azure Queue fallback if Hangfire unavailable.
+  3. Invoke `ICelebrationSmsProvider.SendAsync` using MSG91 template ids from configuration.
+  4. Record log entries with status transitions (`Sent` -> `Delivered` via callback/webhook).
+  5. Retry policy: exponential backoff up to three attempts; terminal failure flagged in dashboard summary.
+
+## Error Contract
+All responses adhere to the shared error format:
+```json
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Invalid phone number",
+    "details": ["Phone must be +91XXXXXXXXXX"],
+    "timestamp": "2025-09-29T22:30:00+05:30"
+  }
+}
+```
+
+## Security & Auditing
+- Leverage existing ASP.NET Identity lockout rules (5 failed attempts, 15 minutes).
+- Every endpoint logs success/failure with `AuditTrail` entries for 90-day retention.
+- Rate limit webhook and test endpoints to prevent abuse.
+

--- a/docs/celebration-dashboard/Database-Spec.md
+++ b/docs/celebration-dashboard/Database-Spec.md
@@ -1,0 +1,107 @@
+# Celebration Database Specification
+
+## Schema Overview
+- **Database**: `EdPickerDB`
+- **Schema**: `celebration` (new)
+- Tables and indexes extend existing database while maintaining isolation from current lesson planner data.
+
+## Tables
+
+### `celebration.Students`
+| Column | Type | Constraints | Notes |
+| --- | --- | --- | --- |
+| `StudentId` | `INT IDENTITY(1,1)` | PK | |
+| `AdminId` | `INT` | FK `dbo.Admins(AdminId)` | Enforces per-school isolation |
+| `Name` | `NVARCHAR(100)` | NOT NULL | |
+| `DOB` | `DATE` | NOT NULL | Stored as calendar date |
+| `Phone` | `VARCHAR(13)` | NOT NULL | Format `+91XXXXXXXXXX`; unique per AdminId + Student |
+| `Consent` | `BIT` | NOT NULL DEFAULT 1 | |
+| `CreatedAt` | `DATETIMEOFFSET(0)` | NOT NULL DEFAULT `SYSUTCDATETIME()` | Convert to IST in app |
+| `UpdatedAt` | `DATETIMEOFFSET(0)` | NOT NULL DEFAULT `SYSUTCDATETIME()` | Updated via trigger |
+| `RowVersion` | `ROWVERSION` | | Supports optimistic concurrency |
+
+**Indexes**:
+- `IX_Students_Admin_DOB_Consent` on (`AdminId`, `DOB`, `Consent`).
+- `IX_Students_Phone` unique on (`AdminId`, `Phone`, `Consent`).
+
+### `celebration.Teachers`
+Similar structure with additional nullable `Anniversary` column (`DATE NULL`).
+
+**Indexes**:
+- `IX_Teachers_Admin_DOB_Consent` on (`AdminId`, `DOB`, `Consent`).
+- `IX_Teachers_Admin_Anniversary_Consent` on (`AdminId`, `Anniversary`, `Consent`).
+- `IX_Teachers_Phone` unique on (`AdminId`, `Phone`, `Consent`).
+
+### `celebration.CelebrationLogs`
+| Column | Type | Constraints |
+| --- | --- | --- |
+| `LogId` | `BIGINT IDENTITY(1,1)` | PK |
+| `AdminId` | `INT` | FK |
+| `RecipientType` | `VARCHAR(10)` | CHECK IN ('Student','Teacher') |
+| `RecipientId` | `INT` | NOT NULL |
+| `RecipientName` | `NVARCHAR(100)` | NOT NULL |
+| `EventType` | `VARCHAR(12)` | CHECK IN ('Birthday','Anniversary') |
+| `Phone` | `VARCHAR(13)` | NOT NULL |
+| `Message` | `NVARCHAR(160)` | NOT NULL |
+| `Status` | `VARCHAR(10)` | CHECK IN ('Pending','Sent','Delivered','Failed') |
+| `SentAt` | `DATETIMEOFFSET(0)` | NOT NULL |
+| `DeliveredAt` | `DATETIMEOFFSET(0)` | NULL |
+| `FailureReason` | `NVARCHAR(200)` | NULL |
+| `CreatedAt` | `DATETIMEOFFSET(0)` | NOT NULL DEFAULT `SYSUTCDATETIME()` |
+
+**Indexes**:
+- `IX_Logs_Admin_SentAt` on (`AdminId`, `SentAt` DESC).
+- `IX_Logs_Phone_SentAt` on (`Phone`, `SentAt` DESC).
+- `IX_Logs_Status` on (`AdminId`, `Status`).
+
+### `celebration.AuditTrail`
+Extends existing audit structure while scoped per schema.
+
+| Column | Type |
+| --- | --- |
+| `AuditId` | `BIGINT IDENTITY(1,1)` |
+| `AdminId` | `INT` |
+| `Action` | `VARCHAR(20)` | Values: Upload, Send, OptOut |
+| `Details` | `NVARCHAR(400)` |
+| `Timestamp` | `DATETIMEOFFSET(0)` | DEFAULT `SYSUTCDATETIME()` |
+
+**Indexes**: `IX_Audit_Admin_Timestamp` on (`AdminId`, `Timestamp` DESC).
+
+### `celebration.FailedLogins`
+If reuse not desired, create new table mirroring security requirements.
+
+| Column | Type |
+| --- | --- |
+| `LogId` | `BIGINT IDENTITY(1,1)` |
+| `Username` | `NVARCHAR(100)` |
+| `Timestamp` | `DATETIMEOFFSET(0)` | DEFAULT `SYSUTCDATETIME()` |
+| `IpAddress` | `VARCHAR(45)` | NULL |
+
+Index on (`Username`, `Timestamp` DESC).
+
+### `celebration.Configuration`
+Stores per-admin preferences.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `AdminId` | `INT` | PK/FK |
+| `SchoolName` | `NVARCHAR(100)` | |
+| `CreatedAt` | `DATETIMEOFFSET(0)` | |
+| `UpdatedAt` | `DATETIMEOFFSET(0)` | |
+
+## Stored Procedures & Functions
+- `celebration.usp_GetTodayEvents @AdminId INT, @Date DATE` – returns teacher rows with SMS status and student counts.
+- `celebration.usp_GetLogs @AdminId INT, @Date DATE, @Status VARCHAR(10), @Page INT, @PageSize INT` – returns paginated logs with total count via `OUTPUT` parameter.
+- `celebration.usp_PruneOldData @RetentionDays INT` – deletes logs/audit records older than retention (default 90 days). Scheduled nightly.
+
+## Triggers
+- `celebration.trg_Students_SetUpdatedAt` and `celebration.trg_Teachers_SetUpdatedAt` update `UpdatedAt` on modifications.
+- Optional trigger to cascade consent changes to associated logs if required for compliance notes.
+
+## Seed Data
+Migration seeds ten sample records (five students, five teachers) per admin for QA environments. Use deterministic names and IST timestamps.
+
+## Retention & Maintenance
+- Hangfire job `celebration-PruneRetention` executes `usp_PruneOldData` daily at 01:00 IST.
+- Monitor row counts; add partitioning if >1M logs.
+

--- a/docs/celebration-dashboard/Integration-Guide.md
+++ b/docs/celebration-dashboard/Integration-Guide.md
@@ -1,0 +1,77 @@
+# Celebration Dashboard Integration Guide
+
+## Purpose
+This guide outlines how the Celebration feature set plugs into the current EdPicker platform architecture across UI, API, and operations. It assumes existing principal authentication flows and reuses infrastructure choices already adopted for the Lesson Planner.
+
+## High-Level Architecture
+1. **edpicker-ui** delivers the `/celebration/dashboard` Angular module following HomeComponent conventions.
+2. **edpicker-api** exposes `/api/celebration` endpoints backed by a dedicated `celebration` schema inside `EdPickerDB`.
+3. **Hangfire** (or Azure WebJob alternative) orchestrates daily SMS jobs and retention pruning.
+4. **MSG91** handles transactional SMS delivery using DLT-compliant templates stored in configuration.
+
+## Authentication & Authorization
+- Reuse existing login experience; principal role gains access to the Celebration card and API endpoints.
+- Server side leverages ASP.NET Identity with lockout (5 attempts, 15 minutes) and 30-minute session expiration.
+- Audit trail entries record login failures under `celebration.FailedLogins` when relevant.
+
+## Navigation Integration Steps
+1. Add a new card definition in the home dashboard component referencing the `/celebration/dashboard` route.
+2. Ensure lazy loading module registration to prevent unnecessary bundle size increase for other flows.
+3. Guard the route with the same `AuthGuard` used by planner features.
+
+## State & Data Flow
+- **Profiles**: Uploads and manual edits call `POST /api/celebration/profiles/*`. Successful imports raise a green toast and trigger a refresh of Today data.
+- **Dashboard**: UI retrieves `GET /api/celebration/dashboard/today` on load and subsequent polling. History tab issues `GET /api/celebration/dashboard/history` with chosen filters.
+- **Configuration**: School name persisted via `POST /api/celebration/config/school`; backend stores per AdminId for template personalization.
+- **Opt-Out**: MSG91 webhook posts to `/api/celebration/webhook/optout` updating consent flags. UI surfaces opt-out in History via status column.
+
+## Background Processing
+- Register Hangfire server in `Program.cs` with SQL Server storage using existing connection string.
+- Configure recurring jobs during application startup:
+  ```csharp
+  RecurringJob.AddOrUpdate(
+      "celebration-daily-sms",
+      () => celebrationService.SendDailyRemindersAsync(),
+      "30 3 * * *", // 9:00 AM IST
+      TimeZoneInfo.Utc);
+
+  RecurringJob.AddOrUpdate(
+      "celebration-retention",
+      () => celebrationService.PruneRetentionAsync(),
+      Cron.Daily(19, 30)); // 1:00 AM IST
+  ```
+- Wire MSG91 delivery callbacks to update `CelebrationLogs` status; fallback to polling if webhook unavailable.
+
+## Configuration Management
+Add the following keys to `appsettings.json` (and secure secrets in Azure Key Vault or App Service settings):
+```json
+"Celebration": {
+  "DlTTemplateBirthday": "<template-id>",
+  "DlTTemplateAnniversary": "<template-id>",
+  "SenderId": "SCHLBDY",
+  "PeId": "<pe-id>",
+  "BatchSizePerHour": 100,
+  "RetentionDays": 90
+},
+"Msg91": {
+  "ApiKey": "<msg91-key>",
+  "BaseUrl": "https://api.msg91.com"
+}
+```
+
+## Deployment Considerations
+- Ensure Hangfire dashboard access is restricted (e.g., behind admin auth or IP safelist).
+- Include migration execution step in CI/CD to create `celebration` schema.
+- Coordinate DLT template approval and MSG91 sender header setup before production launch.
+- Configure Application Insights custom events for SMS send outcomes and webhook failures.
+
+## Testing Strategy Alignment
+- Unit tests cover services (import parsing, SMS scheduling, webhook handling).
+- Integration tests mimic CSV upload -> cron job -> dashboard retrieval -> opt-out flows.
+- Performance tests confirm 5,000 profile uploads <10s and daily dashboard response <2s.
+
+## Future Enhancements Placeholder
+- Personalised SMS content once AI personalization is permitted.
+- Multi-role support leveraging `Role` field in `Admins` table.
+- Optional Azure Function replacement if Hangfire adoption changes.
+

--- a/docs/celebration-dashboard/UI-Spec.md
+++ b/docs/celebration-dashboard/UI-Spec.md
@@ -1,0 +1,61 @@
+# Celebration Dashboard UI Specification
+
+## Overview
+The Celebration Dashboard is a new single-function experience exposed at `/celebration/dashboard` within **edpicker-ui**. It targets the existing principal-level administrator persona and mirrors the established HomeComponent architectural patterns for state management, error handling, and responsive behavior.
+
+## Navigation
+- Add a **Celebration** card to the existing edpicker home grid. Selecting this card routes the user to `/celebration/dashboard`.
+- Visibility aligns with the current principal login role; no alternate roles are introduced in this phase.
+
+## Layout & Structure
+The dashboard comprises three core feature areas organised into tabs:
+
+1. **Today Tab (default)**
+   - **Teacher Events Table**
+     - Angular Material table with columns: `Name`, `Event` (Birthday/Anniversary), `Phone`, `Status` (Sent/Delivered/Failed), `SentAt` (IST, `dd MMM yyyy, hh:mm a`).
+     - Paginate at 20 rows per page; maintain HomeComponent paginator style.
+     - On mobile (<768px) switch to accordion list (one panel per teacher) with the same fields and quick status indicator chips.
+   - **Student Summary Card**
+     - Prominent card showing `X Birthdays Today`.
+     - When the count is <50 provide an expandable list mirroring the teacher accordion styling.
+   - **Delivery Summary Bar**
+     - Display total events processed, delivery success percentage, and failure count using compact statistic cards.
+   - **Alerts Region**
+     - Red banner for failed SMS deliveries with count and CTA to open history filtered to failures.
+
+2. **History Tab**
+   - Angular Material table listing CelebrationLogs records for the selected date (default today).
+   - Filters:
+     - Date picker supporting past 90 days plus future preview.
+     - Search box filtering by `RecipientName`.
+     - Status filter (All/Sent/Delivered/Failed).
+   - Paginate at 50 rows per page, matching backend response slices.
+
+3. **Profiles & Configuration Drawer**
+   - Right-side responsive drawer (modal fallback on narrow viewports) providing:
+     - **Profile Upload Panel**
+       - Drag-and-drop zone for `.csv` and `.xlsx` files.
+       - Downloadable template link describing the required columns: `Type,Name,DOB,Anniversary,Phone,Consent`.
+       - Upload preview grid with inline edit/delete before committing.
+       - Submission triggers `POST /api/celebration/profiles/upload`.
+     - **Manual Entry Forms**
+       - Tabs for Student and Teacher entries matching upload columns.
+       - Consent checkbox defaulted to checked; disabling shows a confirmation modal.
+     - **School Name Configuration**
+       - Input with validation (required, 4–100 chars) stored via `POST /api/celebration/config/school`.
+
+## Interaction Patterns
+- Reuse HomeComponent `LoaderService` for NgxSpinner integration during API calls.
+- Errors follow the established notification hierarchy: green toast (success), yellow banner (warnings), red dialog (critical failures).
+- Implement auto-refresh polling every 60 seconds on the Today tab to surface new SMS outcomes.
+- Respect 44px minimum touch targets and responsive breakpoints (320px, 768px, 1024px).
+- Cache the last selected tab and filters in local storage to improve mobile return visits.
+
+## Accessibility & Localization
+- All interactive controls support keyboard navigation and ARIA labels consistent with Angular Material defaults.
+- Time fields are displayed in IST with tooltips showing absolute timestamps.
+
+## Empty & Error States
+- When no events exist for a date show an illustration placeholder with the message "No celebrations scheduled." and a shortcut to open profile upload.
+- Failed API calls surface the descriptive error message returned from the backend and retain the user’s in-progress form data.
+

--- a/edpicker-api/Controllers/CelebrationController.cs
+++ b/edpicker-api/Controllers/CelebrationController.cs
@@ -1,0 +1,221 @@
+using System.Security.Claims;
+using edpicker_api.Models.Celebration.Dtos;
+using edpicker_api.Services.Interface;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace edpicker_api.Controllers;
+
+[Authorize]
+[ApiController]
+[Route("api/celebration")]
+public class CelebrationController : ControllerBase
+{
+    private readonly ICelebrationService _celebrationService;
+    private readonly ILogger<CelebrationController> _logger;
+
+    public CelebrationController(ICelebrationService celebrationService, ILogger<CelebrationController> logger)
+    {
+        _celebrationService = celebrationService;
+        _logger = logger;
+    }
+
+    [HttpPost("profiles/upload")]
+    public async Task<IActionResult> UploadProfiles([FromForm] IFormFile file, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var adminId = GetCurrentAdminId();
+            var result = await _celebrationService.UploadProfilesAsync(adminId, file, cancellationToken);
+            return Ok(new { success = true, data = result });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to upload celebration profiles");
+            return MapError(ex, "Failed to upload profiles");
+        }
+    }
+
+    [HttpPost("profiles/students")]
+    public async Task<IActionResult> UpsertStudent([FromBody] StudentUpsertRequest request, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            var adminId = GetCurrentAdminId();
+            var result = await _celebrationService.UpsertStudentAsync(adminId, request, cancellationToken);
+            return Ok(new { success = true, data = result });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to upsert student");
+            return MapError(ex, "Failed to save student");
+        }
+    }
+
+    [HttpPost("profiles/teachers")]
+    public async Task<IActionResult> UpsertTeacher([FromBody] TeacherUpsertRequest request, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            var adminId = GetCurrentAdminId();
+            var result = await _celebrationService.UpsertTeacherAsync(adminId, request, cancellationToken);
+            return Ok(new { success = true, data = result });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to upsert teacher");
+            return MapError(ex, "Failed to save teacher");
+        }
+    }
+
+    [HttpGet("dashboard/today")]
+    public async Task<IActionResult> GetTodayDashboard(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var adminId = GetCurrentAdminId();
+            var result = await _celebrationService.GetTodayDashboardAsync(adminId, cancellationToken);
+            return Ok(new { success = true, data = result });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve celebration dashboard");
+            return MapError(ex, "Failed to load dashboard");
+        }
+    }
+
+    [HttpGet("dashboard/history")]
+    public async Task<IActionResult> GetHistory([FromQuery] string date, CancellationToken cancellationToken)
+    {
+        if (!DateOnly.TryParse(date, out var parsedDate))
+        {
+            return BadRequest(new
+            {
+                success = false,
+                error = new
+                {
+                    code = "VALIDATION_ERROR",
+                    message = "Invalid date format. Use YYYY-MM-DD"
+                }
+            });
+        }
+
+        try
+        {
+            var adminId = GetCurrentAdminId();
+            var result = await _celebrationService.GetHistoryAsync(adminId, parsedDate, cancellationToken);
+            return Ok(new { success = true, data = result });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve celebration history for {Date}", date);
+            return MapError(ex, "Failed to load history");
+        }
+    }
+
+    [HttpPost("config/school")]
+    public async Task<IActionResult> SetSchoolName([FromBody] SchoolConfigRequest request, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            var adminId = GetCurrentAdminId();
+            var result = await _celebrationService.SetSchoolNameAsync(adminId, request, cancellationToken);
+            return Ok(new { success = true, data = result });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to set school name");
+            return MapError(ex, "Failed to update school name");
+        }
+    }
+
+    [HttpPost("sms/test")]
+    public async Task<IActionResult> SendTestSms([FromBody] SmsTestRequest request, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            var adminId = GetCurrentAdminId();
+            var result = await _celebrationService.SendTestSmsAsync(adminId, request, cancellationToken);
+            return Ok(new { success = true, data = result });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send test SMS");
+            return MapError(ex, "Failed to send SMS");
+        }
+    }
+
+    [AllowAnonymous]
+    [HttpPost("webhook/optout")]
+    public async Task<IActionResult> HandleOptOut([FromBody] OptOutRequest request, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(ModelState);
+        }
+
+        try
+        {
+            var response = await _celebrationService.HandleOptOutAsync(request, cancellationToken);
+            return Ok(new { success = true, data = response });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to process opt-out webhook");
+            return MapError(ex, "Failed to process opt-out");
+        }
+    }
+
+    private int GetCurrentAdminId()
+    {
+        var userId = User.FindFirst("userId")?.Value ?? User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (int.TryParse(userId, out var adminId))
+        {
+            return adminId;
+        }
+
+        throw new UnauthorizedAccessException("Unable to determine admin id");
+    }
+
+    private ObjectResult MapError(Exception exception, string message)
+    {
+        var statusCode = exception switch
+        {
+            UnauthorizedAccessException => StatusCodes.Status401Unauthorized,
+            ArgumentException => StatusCodes.Status400BadRequest,
+            KeyNotFoundException => StatusCodes.Status404NotFound,
+            _ => StatusCodes.Status500InternalServerError
+        };
+
+        return StatusCode(statusCode, new
+        {
+            success = false,
+            error = new
+            {
+                code = statusCode == StatusCodes.Status400BadRequest ? "VALIDATION_ERROR" : "SERVER_ERROR",
+                message,
+                details = new[] { exception.Message }
+            }
+        });
+    }
+}

--- a/edpicker-api/Models/Celebration/CelebrationOptions.cs
+++ b/edpicker-api/Models/Celebration/CelebrationOptions.cs
@@ -1,0 +1,29 @@
+namespace edpicker_api.Models.Celebration;
+
+public class CelebrationOptions
+{
+    public string ApiKey { get; set; } = string.Empty;
+
+    public string SenderId { get; set; } = "SCHLBDY";
+
+    public string? PeId { get; set; }
+        = null;
+
+    public string? BirthdayTemplateId { get; set; }
+        = null;
+
+    public string? AnniversaryTemplateId { get; set; }
+        = null;
+
+    public string BaseUrl { get; set; } = "https://api.msg91.com/";
+
+    public string TimeZoneId { get; set; } = "Asia/Kolkata";
+
+    public int NotificationHour { get; set; } = 9;
+
+    public int NotificationMinute { get; set; } = 0;
+
+    public int SendRetryLimit { get; set; } = 3;
+
+    public int LogRetentionDays { get; set; } = 90;
+}

--- a/edpicker-api/Models/Celebration/Dtos/DashboardDtos.cs
+++ b/edpicker-api/Models/Celebration/Dtos/DashboardDtos.cs
@@ -1,0 +1,48 @@
+using edpicker_api.Models.Celebration.Enums;
+
+namespace edpicker_api.Models.Celebration.Dtos;
+
+public record TeacherEventDto(
+    int TeacherId,
+    string Name,
+    CelebrationEventType EventType,
+    string Phone,
+    CelebrationDeliveryStatus Status,
+    int Attempt,
+    DateTimeOffset? SentAt,
+    string? FailureReason
+);
+
+public record StudentSummaryDto(
+    int StudentId,
+    string Name,
+    string Phone
+);
+
+public record DashboardAlertDto(
+    string Message,
+    string Severity
+);
+
+public class TodayDashboardResponse
+{
+    public DateOnly Date { get; init; }
+
+    public string? SchoolName { get; init; }
+
+    public IReadOnlyCollection<TeacherEventDto> Teachers { get; init; } = Array.Empty<TeacherEventDto>();
+
+    public int StudentsCount { get; init; }
+
+    public IReadOnlyCollection<StudentSummaryDto> Students { get; init; } = Array.Empty<StudentSummaryDto>();
+
+    public int TotalEvents { get; init; }
+
+    public int TotalSent { get; init; }
+
+    public int TotalFailed { get; init; }
+
+    public decimal DeliverySuccessRate { get; init; }
+
+    public IReadOnlyCollection<DashboardAlertDto> Alerts { get; init; } = Array.Empty<DashboardAlertDto>();
+}

--- a/edpicker-api/Models/Celebration/Dtos/HistoryDtos.cs
+++ b/edpicker-api/Models/Celebration/Dtos/HistoryDtos.cs
@@ -1,0 +1,23 @@
+using edpicker_api.Models.Celebration.Enums;
+
+namespace edpicker_api.Models.Celebration.Dtos;
+
+public record HistoryLogDto(
+    long LogId,
+    CelebrationRecipientType RecipientType,
+    string RecipientName,
+    CelebrationEventType EventType,
+    string Phone,
+    CelebrationDeliveryStatus Status,
+    int Attempt,
+    DateTimeOffset SentAt,
+    string Message,
+    string? FailureReason
+);
+
+public class HistoryResponse
+{
+    public DateOnly Date { get; init; }
+
+    public IReadOnlyCollection<HistoryLogDto> Logs { get; init; } = Array.Empty<HistoryLogDto>();
+}

--- a/edpicker-api/Models/Celebration/Dtos/OptOutRequest.cs
+++ b/edpicker-api/Models/Celebration/Dtos/OptOutRequest.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace edpicker_api.Models.Celebration.Dtos;
+
+public class OptOutRequest
+{
+    [Required]
+    [MaxLength(20)]
+    public string Phone { get; set; } = string.Empty;
+
+    [MaxLength(200)]
+    public string? Message { get; set; }
+        = null;
+}
+
+public class OptOutResponse
+{
+    public bool Updated { get; init; }
+}

--- a/edpicker-api/Models/Celebration/Dtos/SchoolConfigDtos.cs
+++ b/edpicker-api/Models/Celebration/Dtos/SchoolConfigDtos.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace edpicker_api.Models.Celebration.Dtos;
+
+public class SchoolConfigRequest
+{
+    [Required]
+    [MaxLength(120)]
+    public string SchoolName { get; set; } = string.Empty;
+}
+
+public class SchoolConfigResponse
+{
+    public string SchoolName { get; init; } = string.Empty;
+
+    public DateTimeOffset UpdatedAt { get; init; }
+        = DateTimeOffset.UtcNow;
+}

--- a/edpicker-api/Models/Celebration/Dtos/SmsTestRequest.cs
+++ b/edpicker-api/Models/Celebration/Dtos/SmsTestRequest.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+using edpicker_api.Models.Celebration.Enums;
+
+namespace edpicker_api.Models.Celebration.Dtos;
+
+public class SmsTestRequest
+{
+    [Required]
+    public int RecipientId { get; set; }
+
+    [Required]
+    public CelebrationRecipientType RecipientType { get; set; }
+        = CelebrationRecipientType.Student;
+
+    [MaxLength(180)]
+    public string? Message { get; set; }
+        = null;
+}
+
+public class SmsSendResultDto
+{
+    public bool Success { get; init; }
+
+    public string? Error { get; init; }
+        = null;
+}

--- a/edpicker-api/Models/Celebration/Dtos/StudentUpsertRequest.cs
+++ b/edpicker-api/Models/Celebration/Dtos/StudentUpsertRequest.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace edpicker_api.Models.Celebration.Dtos;
+
+public class StudentUpsertRequest
+{
+    public int? StudentId { get; set; }
+
+    [Required]
+    [MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    public DateOnly DateOfBirth { get; set; }
+        = DateOnly.FromDateTime(DateTime.UtcNow);
+
+    [Required]
+    [RegularExpression("^\\+91[0-9]{10}$", ErrorMessage = "Phone must be in +91XXXXXXXXXX format")] 
+    public string Phone { get; set; } = string.Empty;
+
+    public bool Consent { get; set; } = true;
+}

--- a/edpicker-api/Models/Celebration/Dtos/TeacherUpsertRequest.cs
+++ b/edpicker-api/Models/Celebration/Dtos/TeacherUpsertRequest.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace edpicker_api.Models.Celebration.Dtos;
+
+public class TeacherUpsertRequest
+{
+    public int? TeacherId { get; set; }
+
+    [Required]
+    [MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    public DateOnly DateOfBirth { get; set; }
+        = DateOnly.FromDateTime(DateTime.UtcNow);
+
+    public DateOnly? Anniversary { get; set; }
+        = null;
+
+    [Required]
+    [RegularExpression("^\\+91[0-9]{10}$", ErrorMessage = "Phone must be in +91XXXXXXXXXX format")]
+    public string Phone { get; set; } = string.Empty;
+
+    public bool Consent { get; set; } = true;
+}

--- a/edpicker-api/Models/Celebration/Dtos/UploadProfilesResult.cs
+++ b/edpicker-api/Models/Celebration/Dtos/UploadProfilesResult.cs
@@ -1,0 +1,8 @@
+namespace edpicker_api.Models.Celebration.Dtos;
+
+public class UploadProfilesResult
+{
+    public int Imported { get; init; }
+
+    public IReadOnlyCollection<string> Errors { get; init; } = Array.Empty<string>();
+}

--- a/edpicker-api/Models/Celebration/Entities/CelebrationAuditLog.cs
+++ b/edpicker-api/Models/Celebration/Entities/CelebrationAuditLog.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+using edpicker_api.Models.Celebration.Enums;
+
+namespace edpicker_api.Models.Celebration.Entities;
+
+/// <summary>
+/// Tracks user actions within the celebration module for compliance.
+/// </summary>
+public class CelebrationAuditLog
+{
+    [Key]
+    public long AuditId { get; set; }
+
+    [Required]
+    public int AdminId { get; set; }
+
+    [Required]
+    public CelebrationAuditAction Action { get; set; }
+        = CelebrationAuditAction.Upload;
+
+    [MaxLength(400)]
+    public string? Details { get; set; }
+        = null;
+
+    public DateTimeOffset Timestamp { get; set; }
+        = DateTimeOffset.UtcNow;
+}

--- a/edpicker-api/Models/Celebration/Entities/CelebrationConfiguration.cs
+++ b/edpicker-api/Models/Celebration/Entities/CelebrationConfiguration.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace edpicker_api.Models.Celebration.Entities;
+
+/// <summary>
+/// Stores per-admin configuration for celebration messaging.
+/// </summary>
+public class CelebrationConfiguration
+{
+    [Key]
+    public int AdminId { get; set; }
+
+    [Required]
+    [MaxLength(120)]
+    public string SchoolName { get; set; } = string.Empty;
+
+    public DateTimeOffset UpdatedAt { get; set; }
+        = DateTimeOffset.UtcNow;
+}

--- a/edpicker-api/Models/Celebration/Entities/CelebrationLog.cs
+++ b/edpicker-api/Models/Celebration/Entities/CelebrationLog.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel.DataAnnotations;
+using edpicker_api.Models.Celebration.Enums;
+
+namespace edpicker_api.Models.Celebration.Entities;
+
+/// <summary>
+/// Represents an SMS delivery attempt for the celebration feature.
+/// </summary>
+public class CelebrationLog
+{
+    [Key]
+    public long LogId { get; set; }
+
+    [Required]
+    public int AdminId { get; set; }
+
+    [Required]
+    public CelebrationRecipientType RecipientType { get; set; }
+
+    public int? RecipientId { get; set; }
+
+    [Required]
+    [MaxLength(100)]
+    public string RecipientName { get; set; } = string.Empty;
+
+    [Required]
+    public CelebrationEventType EventType { get; set; }
+
+    [Required]
+    [MaxLength(15)]
+    public string Phone { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(180)]
+    public string Message { get; set; } = string.Empty;
+
+    [Required]
+    public CelebrationDeliveryStatus Status { get; set; }
+        = CelebrationDeliveryStatus.Sent;
+
+    [MaxLength(250)]
+    public string? FailureReason { get; set; }
+        = null;
+
+    public int Attempt { get; set; } = 1;
+
+    public DateOnly EventDate { get; set; }
+        = DateOnly.FromDateTime(DateTime.UtcNow);
+
+    public DateTimeOffset SentAt { get; set; }
+        = DateTimeOffset.UtcNow;
+}

--- a/edpicker-api/Models/Celebration/Entities/CelebrationStudent.cs
+++ b/edpicker-api/Models/Celebration/Entities/CelebrationStudent.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace edpicker_api.Models.Celebration.Entities;
+
+/// <summary>
+/// Represents a student profile used for celebration reminders.
+/// </summary>
+public class CelebrationStudent
+{
+    [Key]
+    public int StudentId { get; set; }
+
+    [Required]
+    public int AdminId { get; set; }
+
+    [Required]
+    [MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    public DateOnly DateOfBirth { get; set; }
+
+    [Required]
+    [MaxLength(15)]
+    public string Phone { get; set; } = string.Empty;
+
+    public bool Consent { get; set; } = true;
+
+    public DateTimeOffset CreatedAt { get; set; }
+        = DateTimeOffset.UtcNow;
+
+    public DateTimeOffset? UpdatedAt { get; set; }
+        = null;
+}

--- a/edpicker-api/Models/Celebration/Entities/CelebrationTeacher.cs
+++ b/edpicker-api/Models/Celebration/Entities/CelebrationTeacher.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace edpicker_api.Models.Celebration.Entities;
+
+/// <summary>
+/// Represents a teacher profile that can receive celebration reminders.
+/// </summary>
+public class CelebrationTeacher
+{
+    [Key]
+    public int TeacherId { get; set; }
+
+    [Required]
+    public int AdminId { get; set; }
+
+    [Required]
+    [MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    public DateOnly DateOfBirth { get; set; }
+        = DateOnly.FromDateTime(DateTime.UtcNow);
+
+    public DateOnly? Anniversary { get; set; }
+        = null;
+
+    [Required]
+    [MaxLength(15)]
+    public string Phone { get; set; } = string.Empty;
+
+    public bool Consent { get; set; } = true;
+
+    public DateTimeOffset CreatedAt { get; set; }
+        = DateTimeOffset.UtcNow;
+
+    public DateTimeOffset? UpdatedAt { get; set; }
+        = null;
+}

--- a/edpicker-api/Models/Celebration/Enums/CelebrationAuditAction.cs
+++ b/edpicker-api/Models/Celebration/Enums/CelebrationAuditAction.cs
@@ -1,0 +1,12 @@
+namespace edpicker_api.Models.Celebration.Enums;
+
+public enum CelebrationAuditAction
+{
+    Upload = 1,
+    UpsertStudent = 2,
+    UpsertTeacher = 3,
+    Send = 4,
+    OptOut = 5,
+    ConfigureSchool = 6,
+    TestSms = 7
+}

--- a/edpicker-api/Models/Celebration/Enums/CelebrationDeliveryStatus.cs
+++ b/edpicker-api/Models/Celebration/Enums/CelebrationDeliveryStatus.cs
@@ -1,0 +1,8 @@
+namespace edpicker_api.Models.Celebration.Enums;
+
+public enum CelebrationDeliveryStatus
+{
+    Sent = 1,
+    Delivered = 2,
+    Failed = 3
+}

--- a/edpicker-api/Models/Celebration/Enums/CelebrationEventType.cs
+++ b/edpicker-api/Models/Celebration/Enums/CelebrationEventType.cs
@@ -1,0 +1,7 @@
+namespace edpicker_api.Models.Celebration.Enums;
+
+public enum CelebrationEventType
+{
+    Birthday = 1,
+    Anniversary = 2
+}

--- a/edpicker-api/Models/Celebration/Enums/CelebrationRecipientType.cs
+++ b/edpicker-api/Models/Celebration/Enums/CelebrationRecipientType.cs
@@ -1,0 +1,7 @@
+namespace edpicker_api.Models.Celebration.Enums;
+
+public enum CelebrationRecipientType
+{
+    Student = 1,
+    Teacher = 2
+}

--- a/edpicker-api/Models/EdPickerDbContext.cs
+++ b/edpicker-api/Models/EdPickerDbContext.cs
@@ -1,4 +1,5 @@
 using edpicker_api.Models;
+using edpicker_api.Models.Celebration.Entities;
 using edpicker_api.Models.Dto;
 using edpicker_api.Models.Job;
 using edpicker_api.Models.Planner.Entities;
@@ -33,6 +34,12 @@ public class EdPickerDbContext : DbContext
     public DbSet<CurriculumInstance> CurriculumInstances { get; set; }
     public DbSet<TopicCompletion> TopicCompletions { get; set; }
     public DbSet<AuditLog> AuditLogs { get; set; }
+
+    public DbSet<CelebrationStudent> CelebrationStudents { get; set; }
+    public DbSet<CelebrationTeacher> CelebrationTeachers { get; set; }
+    public DbSet<CelebrationLog> CelebrationLogs { get; set; }
+    public DbSet<CelebrationAuditLog> CelebrationAuditLogs { get; set; }
+    public DbSet<CelebrationConfiguration> CelebrationConfigurations { get; set; }
 
     public EdPickerDbContext(DbContextOptions<EdPickerDbContext> options)
       : base(options) { }
@@ -80,6 +87,7 @@ public class EdPickerDbContext : DbContext
         modelBuilder.Entity<SchoolClassDto>().HasNoKey().ToView(null);
 
         ConfigurePlannerModel(modelBuilder);
+        ConfigureCelebrationModel(modelBuilder);
     }
 
     private static void ConfigurePlannerModel(ModelBuilder modelBuilder)
@@ -153,5 +161,43 @@ public class EdPickerDbContext : DbContext
             .HasMany(y => y.CurriculumInstances)
             .WithOne(ci => ci.AcademicYear)
             .HasForeignKey(ci => ci.AcademicYearId);
+    }
+
+    private static void ConfigureCelebrationModel(ModelBuilder modelBuilder)
+    {
+        const string schema = "celebration";
+
+        modelBuilder.Entity<CelebrationStudent>(entity =>
+        {
+            entity.ToTable("Students", schema);
+            entity.HasIndex(e => new { e.AdminId, e.DateOfBirth }).HasDatabaseName("IX_CelebrationStudents_Admin_Dob");
+            entity.HasIndex(e => new { e.AdminId, e.Phone }).HasDatabaseName("IX_CelebrationStudents_Admin_Phone");
+        });
+
+        modelBuilder.Entity<CelebrationTeacher>(entity =>
+        {
+            entity.ToTable("Teachers", schema);
+            entity.HasIndex(e => new { e.AdminId, e.DateOfBirth }).HasDatabaseName("IX_CelebrationTeachers_Admin_Dob");
+            entity.HasIndex(e => new { e.AdminId, e.Anniversary }).HasDatabaseName("IX_CelebrationTeachers_Admin_Anniv");
+            entity.HasIndex(e => new { e.AdminId, e.Phone }).HasDatabaseName("IX_CelebrationTeachers_Admin_Phone");
+        });
+
+        modelBuilder.Entity<CelebrationLog>(entity =>
+        {
+            entity.ToTable("Logs", schema);
+            entity.HasIndex(e => new { e.AdminId, e.EventDate }).HasDatabaseName("IX_CelebrationLogs_Admin_Date");
+            entity.HasIndex(e => new { e.AdminId, e.RecipientType, e.RecipientId, e.EventDate }).HasDatabaseName("IX_CelebrationLogs_Recipient_Date");
+        });
+
+        modelBuilder.Entity<CelebrationAuditLog>(entity =>
+        {
+            entity.ToTable("AuditTrail", schema);
+            entity.HasIndex(e => new { e.AdminId, e.Timestamp }).HasDatabaseName("IX_CelebrationAudit_Admin_Timestamp");
+        });
+
+        modelBuilder.Entity<CelebrationConfiguration>(entity =>
+        {
+            entity.ToTable("Configuration", schema);
+        });
     }
 }

--- a/edpicker-api/Program.cs
+++ b/edpicker-api/Program.cs
@@ -3,13 +3,18 @@ using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 using edpicker_api;
 using edpicker_api.Models;
+using edpicker_api.Models.Celebration;
 using edpicker_api.Services;
 using edpicker_api.Services.Interface;
+using Hangfire;
+using Hangfire.SqlServer;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using OpenAI;
-using Microsoft.AspNetCore.Diagnostics;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -44,7 +49,28 @@ try
     builder.Services.AddScoped<IUserRepository, UserRepository>();
     builder.Services.AddScoped<ICommonRepository, CommonRepository>();
     builder.Services.AddScoped<ILoginRepository, LoginRepository>();
+    builder.Services.Configure<CelebrationOptions>(builder.Configuration.GetSection("Celebration"));
+    builder.Services.AddSingleton(TimeProvider.System);
+    builder.Services.AddScoped<ICelebrationService, CelebrationService>();
+    builder.Services.AddHangfire(configuration => configuration
+        .UseSimpleAssemblyNameTypeSerializer()
+        .UseRecommendedSerializerSettings()
+        .UseSqlServerStorage(builder.Configuration.GetConnectionString("DefaultConnection"), new SqlServerStorageOptions
+        {
+            CommandBatchMaxTimeout = TimeSpan.FromMinutes(5),
+            SlidingInvisibilityTimeout = TimeSpan.FromMinutes(5),
+            QueuePollInterval = TimeSpan.FromSeconds(15),
+            UseRecommendedIsolationLevel = true,
+            DisableGlobalLocks = true
+        }));
+    builder.Services.AddHangfireServer();
     builder.Services.AddHttpClient();
+    builder.Services.AddHttpClient("msg91", client =>
+    {
+        var baseUrl = builder.Configuration.GetSection("Celebration")?["BaseUrl"] ?? "https://api.msg91.com/";
+        client.BaseAddress = new Uri(baseUrl);
+        client.Timeout = TimeSpan.FromSeconds(30);
+    });
 }
 catch (Exception ex)
 {
@@ -117,6 +143,7 @@ app.UseCors("AllowSpecificOrigins");
 app.UseHttpsRedirection();
 app.UseAuthentication(); // <--- Add this BEFORE app.UseAuthorization()
 app.UseAuthorization();
+app.UseHangfireDashboard();
 
 // Return a simple message on the root endpoint so the service can be probed easily.
 app.MapGet("/", () =>
@@ -125,6 +152,8 @@ app.MapGet("/", () =>
         : Results.Problem(startupError));
 
 app.MapControllers();
+
+ScheduleRecurringJobs(app);
 
 app.Run();
 static async Task<string> GetSecretFromKeyVault(IConfiguration configuration, string secretNameConfig)
@@ -146,4 +175,59 @@ static async Task<string> GetSecretFromKeyVault(IConfiguration configuration, st
         Console.WriteLine($"Error retrieving secret: {ex.Message}");
         throw; // Re-throw the exception to prevent the application from running without the key
     }
+}
+
+static void ScheduleRecurringJobs(WebApplication app)
+{
+    try
+    {
+        using var scope = app.Services.CreateScope();
+        var jobManager = scope.ServiceProvider.GetRequiredService<IRecurringJobManager>();
+        var options = scope.ServiceProvider.GetRequiredService<IOptions<CelebrationOptions>>().Value;
+        var timeZone = ResolveTimeZone(options.TimeZoneId);
+
+        jobManager.AddOrUpdate<ICelebrationService>(
+            "celebration-daily-reminders",
+            service => service.SendDailyRemindersAsync(CancellationToken.None),
+            Cron.Daily(options.NotificationHour, options.NotificationMinute),
+            new RecurringJobOptions
+            {
+                TimeZone = timeZone
+            });
+    }
+    catch (Exception ex)
+    {
+        var logger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Hangfire");
+        logger.LogError(ex, "Failed to schedule celebration reminders");
+    }
+}
+
+static TimeZoneInfo ResolveTimeZone(string? timeZoneId)
+{
+    if (!string.IsNullOrWhiteSpace(timeZoneId))
+    {
+        try
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+
+    var fallbacks = new[] { "Asia/Kolkata", "India Standard Time" };
+    foreach (var candidate in fallbacks)
+    {
+        try
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById(candidate);
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+
+    return TimeZoneInfo.Utc;
 }

--- a/edpicker-api/Services/CelebrationService.cs
+++ b/edpicker-api/Services/CelebrationService.cs
@@ -1,0 +1,1085 @@
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using CsvHelper;
+using CsvHelper.Configuration;
+using edpicker_api.Models.Celebration;
+using edpicker_api.Models.Celebration.Dtos;
+using edpicker_api.Models.Celebration.Entities;
+using edpicker_api.Models.Celebration.Enums;
+using edpicker_api.Services.Interface;
+using ExcelDataReader;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace edpicker_api.Services;
+
+public class CelebrationService : ICelebrationService
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+    private static readonly Regex DigitsOnly = new("[0-9]+", RegexOptions.Compiled);
+    private static volatile bool _encodingRegistered;
+
+    private readonly EdPickerDbContext _dbContext;
+    private readonly ILogger<CelebrationService> _logger;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly CelebrationOptions _options;
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeZoneInfo _timeZone;
+
+    public CelebrationService(
+        EdPickerDbContext dbContext,
+        ILogger<CelebrationService> logger,
+        IHttpClientFactory httpClientFactory,
+        IOptions<CelebrationOptions> options,
+        TimeProvider timeProvider)
+    {
+        _dbContext = dbContext;
+        _logger = logger;
+        _httpClientFactory = httpClientFactory;
+        _options = options.Value;
+        _timeProvider = timeProvider;
+        _timeZone = ResolveTimeZone(_options.TimeZoneId);
+    }
+
+    public async Task<UploadProfilesResult> UploadProfilesAsync(int adminId, IFormFile file, CancellationToken cancellationToken)
+    {
+        if (file == null || file.Length == 0)
+        {
+            throw new ArgumentException("File is required", nameof(file));
+        }
+
+        var extension = Path.GetExtension(file.FileName).ToLowerInvariant();
+        var imported = 0;
+        var errors = new List<string>();
+        var now = GetCurrentLocalTime();
+
+        List<UploadRecord> records = extension switch
+        {
+            ".csv" => ParseCsv(file),
+            ".xlsx" or ".xls" => ParseExcel(file),
+            _ => throw new ArgumentException("Unsupported file format. Use .csv or .xlsx", nameof(file))
+        };
+
+        foreach (var record in records)
+        {
+            if (string.IsNullOrWhiteSpace(record.Name))
+            {
+                errors.Add($"Row {record.RowNumber}: Name is required");
+                continue;
+            }
+
+            if (!TryNormalizeType(record.Type, out var type))
+            {
+                errors.Add($"Row {record.RowNumber}: Unknown Type '{record.Type}'");
+                continue;
+            }
+
+            if (!TryNormalizePhone(record.Phone, out var phone, out var phoneError))
+            {
+                errors.Add($"Row {record.RowNumber}: {phoneError}");
+                continue;
+            }
+
+            if (!TryParseDate(record.Dob, out var dob, out var dobError))
+            {
+                errors.Add($"Row {record.RowNumber}: {dobError}");
+                continue;
+            }
+
+            var consent = ParseConsent(record.Consent);
+
+            if (type == CelebrationRecipientType.Student)
+            {
+                var student = new CelebrationStudent
+                {
+                    AdminId = adminId,
+                    Name = record.Name?.Trim() ?? string.Empty,
+                    DateOfBirth = dob,
+                    Phone = phone,
+                    Consent = consent,
+                    CreatedAt = now
+                };
+
+                _dbContext.CelebrationStudents.Add(student);
+                imported++;
+            }
+            else
+            {
+                if (!TryParseAnniversary(record.Anniversary, out var anniversary, out var anniversaryError))
+                {
+                    errors.Add($"Row {record.RowNumber}: {anniversaryError}");
+                    continue;
+                }
+
+                var teacher = new CelebrationTeacher
+                {
+                    AdminId = adminId,
+                    Name = record.Name?.Trim() ?? string.Empty,
+                    DateOfBirth = dob,
+                    Anniversary = anniversary,
+                    Phone = phone,
+                    Consent = consent,
+                    CreatedAt = now
+                };
+
+                _dbContext.CelebrationTeachers.Add(teacher);
+                imported++;
+            }
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        await AddAuditLogAsync(adminId, CelebrationAuditAction.Upload, $"Imported {imported} records", now, cancellationToken);
+
+        return new UploadProfilesResult
+        {
+            Imported = imported,
+            Errors = errors
+        };
+    }
+
+    public async Task<StudentSummaryDto> UpsertStudentAsync(int adminId, StudentUpsertRequest request, CancellationToken cancellationToken)
+    {
+        if (!TryNormalizePhone(request.Phone, out var phone, out var phoneError))
+        {
+            throw new ArgumentException(phoneError ?? "Invalid phone", nameof(request.Phone));
+        }
+
+        var now = GetCurrentLocalTime();
+
+        CelebrationStudent entity;
+        if (request.StudentId.HasValue)
+        {
+            entity = await _dbContext.CelebrationStudents
+                .FirstOrDefaultAsync(s => s.StudentId == request.StudentId && s.AdminId == adminId, cancellationToken)
+                ?? throw new KeyNotFoundException("Student not found");
+
+            entity.Name = request.Name.Trim();
+            entity.DateOfBirth = request.DateOfBirth;
+            entity.Phone = phone;
+            entity.Consent = request.Consent;
+            entity.UpdatedAt = now;
+        }
+        else
+        {
+            entity = new CelebrationStudent
+            {
+                AdminId = adminId,
+                Name = request.Name.Trim(),
+                DateOfBirth = request.DateOfBirth,
+                Phone = phone,
+                Consent = request.Consent,
+                CreatedAt = now
+            };
+
+            _dbContext.CelebrationStudents.Add(entity);
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        await AddAuditLogAsync(adminId, CelebrationAuditAction.UpsertStudent, $"StudentId={entity.StudentId}", now, cancellationToken);
+
+        return new StudentSummaryDto(entity.StudentId, entity.Name, entity.Phone);
+    }
+
+    public async Task<TeacherEventDto> UpsertTeacherAsync(int adminId, TeacherUpsertRequest request, CancellationToken cancellationToken)
+    {
+        if (!TryNormalizePhone(request.Phone, out var phone, out var phoneError))
+        {
+            throw new ArgumentException(phoneError ?? "Invalid phone", nameof(request.Phone));
+        }
+
+        var now = GetCurrentLocalTime();
+
+        CelebrationTeacher entity;
+        if (request.TeacherId.HasValue)
+        {
+            entity = await _dbContext.CelebrationTeachers
+                .FirstOrDefaultAsync(t => t.TeacherId == request.TeacherId && t.AdminId == adminId, cancellationToken)
+                ?? throw new KeyNotFoundException("Teacher not found");
+
+            entity.Name = request.Name.Trim();
+            entity.DateOfBirth = request.DateOfBirth;
+            entity.Anniversary = request.Anniversary;
+            entity.Phone = phone;
+            entity.Consent = request.Consent;
+            entity.UpdatedAt = now;
+        }
+        else
+        {
+            entity = new CelebrationTeacher
+            {
+                AdminId = adminId,
+                Name = request.Name.Trim(),
+                DateOfBirth = request.DateOfBirth,
+                Anniversary = request.Anniversary,
+                Phone = phone,
+                Consent = request.Consent,
+                CreatedAt = now
+            };
+
+            _dbContext.CelebrationTeachers.Add(entity);
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        await AddAuditLogAsync(adminId, CelebrationAuditAction.UpsertTeacher, $"TeacherId={entity.TeacherId}", now, cancellationToken);
+
+        return new TeacherEventDto(
+            entity.TeacherId,
+            entity.Name,
+            CelebrationEventType.Birthday,
+            entity.Phone,
+            CelebrationDeliveryStatus.Sent,
+            0,
+            null,
+            null);
+    }
+
+    public async Task<TodayDashboardResponse> GetTodayDashboardAsync(int adminId, CancellationToken cancellationToken)
+    {
+        var today = GetCurrentLocalDate();
+
+        var schoolName = await _dbContext.CelebrationConfigurations
+            .AsNoTracking()
+            .Where(c => c.AdminId == adminId)
+            .Select(c => c.SchoolName)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        var teacherBirthdays = await _dbContext.CelebrationTeachers
+            .AsNoTracking()
+            .Where(t => t.AdminId == adminId && t.Consent && t.DateOfBirth.Month == today.Month && t.DateOfBirth.Day == today.Day)
+            .Select(t => new { t.TeacherId, t.Name, t.Phone, EventType = CelebrationEventType.Birthday })
+            .ToListAsync(cancellationToken);
+
+        var teacherAnniversaries = await _dbContext.CelebrationTeachers
+            .AsNoTracking()
+            .Where(t => t.AdminId == adminId && t.Consent && t.Anniversary.HasValue && t.Anniversary.Value.Month == today.Month && t.Anniversary.Value.Day == today.Day)
+            .Select(t => new { t.TeacherId, t.Name, t.Phone, EventType = CelebrationEventType.Anniversary })
+            .ToListAsync(cancellationToken);
+
+        var teacherEvents = teacherBirthdays.Concat(teacherAnniversaries).ToList();
+
+        var logs = await _dbContext.CelebrationLogs
+            .AsNoTracking()
+            .Where(l => l.AdminId == adminId && l.EventDate == today)
+            .ToListAsync(cancellationToken);
+
+        var teacherDtos = new List<TeacherEventDto>();
+        foreach (var evt in teacherEvents)
+        {
+            var statusLog = logs
+                .Where(l => l.RecipientType == CelebrationRecipientType.Teacher && l.RecipientId == evt.TeacherId && l.EventType == evt.EventType)
+                .OrderByDescending(l => l.Attempt)
+                .ThenByDescending(l => l.SentAt)
+                .FirstOrDefault();
+
+            teacherDtos.Add(new TeacherEventDto(
+                evt.TeacherId,
+                evt.Name,
+                evt.EventType,
+                evt.Phone,
+                statusLog?.Status ?? CelebrationDeliveryStatus.Sent,
+                statusLog?.Attempt ?? 0,
+                statusLog?.SentAt,
+                statusLog?.FailureReason));
+        }
+
+        var studentBirthdays = await _dbContext.CelebrationStudents
+            .AsNoTracking()
+            .Where(s => s.AdminId == adminId && s.Consent && s.DateOfBirth.Month == today.Month && s.DateOfBirth.Day == today.Day)
+            .Select(s => new StudentSummaryDto(s.StudentId, s.Name, s.Phone))
+            .ToListAsync(cancellationToken);
+
+        var totalEvents = teacherEvents.Count + studentBirthdays.Count;
+        var totalFailed = logs.Count(l => l.Status == CelebrationDeliveryStatus.Failed && l.EventDate == today);
+        var totalSent = logs.Count(l => l.Status != CelebrationDeliveryStatus.Failed && l.EventDate == today);
+        var successRate = totalEvents == 0
+            ? 0
+            : Math.Round((decimal)(totalEvents - totalFailed) / totalEvents * 100, 2);
+
+        var alerts = new List<DashboardAlertDto>();
+        if (totalFailed > 0)
+        {
+            alerts.Add(new DashboardAlertDto($"{totalFailed} messages failed", "error"));
+        }
+
+        return new TodayDashboardResponse
+        {
+            Date = today,
+            SchoolName = schoolName,
+            Teachers = teacherDtos,
+            StudentsCount = studentBirthdays.Count,
+            Students = studentBirthdays.Count <= 50 ? studentBirthdays : Array.Empty<StudentSummaryDto>(),
+            TotalEvents = totalEvents,
+            TotalSent = totalSent,
+            TotalFailed = totalFailed,
+            DeliverySuccessRate = successRate,
+            Alerts = alerts
+        };
+    }
+
+    public async Task<HistoryResponse> GetHistoryAsync(int adminId, DateOnly date, CancellationToken cancellationToken)
+    {
+        var logs = await _dbContext.CelebrationLogs
+            .AsNoTracking()
+            .Where(l => l.AdminId == adminId && l.EventDate == date)
+            .OrderBy(l => l.SentAt)
+            .Select(l => new HistoryLogDto(
+                l.LogId,
+                l.RecipientType,
+                l.RecipientName,
+                l.EventType,
+                l.Phone,
+                l.Status,
+                l.Attempt,
+                l.SentAt,
+                l.Message,
+                l.FailureReason))
+            .ToListAsync(cancellationToken);
+
+        return new HistoryResponse
+        {
+            Date = date,
+            Logs = logs
+        };
+    }
+
+    public async Task<SchoolConfigResponse> SetSchoolNameAsync(int adminId, SchoolConfigRequest request, CancellationToken cancellationToken)
+    {
+        var name = request.SchoolName.Trim();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("SchoolName cannot be empty", nameof(request.SchoolName));
+        }
+
+        var now = GetCurrentLocalTime();
+
+        var config = await _dbContext.CelebrationConfigurations
+            .FirstOrDefaultAsync(c => c.AdminId == adminId, cancellationToken);
+
+        if (config == null)
+        {
+            config = new CelebrationConfiguration
+            {
+                AdminId = adminId,
+                SchoolName = name,
+                UpdatedAt = now
+            };
+
+            _dbContext.CelebrationConfigurations.Add(config);
+        }
+        else
+        {
+            config.SchoolName = name;
+            config.UpdatedAt = now;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        await AddAuditLogAsync(adminId, CelebrationAuditAction.ConfigureSchool, name, now, cancellationToken);
+
+        return new SchoolConfigResponse
+        {
+            SchoolName = config.SchoolName,
+            UpdatedAt = config.UpdatedAt
+        };
+    }
+
+    public async Task<SmsSendResultDto> SendTestSmsAsync(int adminId, SmsTestRequest request, CancellationToken cancellationToken)
+    {
+        var schoolName = await _dbContext.CelebrationConfigurations
+            .AsNoTracking()
+            .Where(c => c.AdminId == adminId)
+            .Select(c => c.SchoolName)
+            .FirstOrDefaultAsync(cancellationToken) ?? "Your School";
+
+        string name;
+        string phone;
+        CelebrationEventType eventType = CelebrationEventType.Birthday;
+
+        if (request.RecipientType == CelebrationRecipientType.Student)
+        {
+            var student = await _dbContext.CelebrationStudents
+                .AsNoTracking()
+                .FirstOrDefaultAsync(s => s.StudentId == request.RecipientId && s.AdminId == adminId, cancellationToken)
+                ?? throw new KeyNotFoundException("Student not found");
+
+            name = student.Name;
+            phone = student.Phone;
+        }
+        else
+        {
+            var teacher = await _dbContext.CelebrationTeachers
+                .AsNoTracking()
+                .FirstOrDefaultAsync(t => t.TeacherId == request.RecipientId && t.AdminId == adminId, cancellationToken)
+                ?? throw new KeyNotFoundException("Teacher not found");
+
+            name = teacher.Name;
+            phone = teacher.Phone;
+            eventType = CelebrationEventType.Anniversary;
+        }
+
+        var outcome = await SendCelebrationMessageAsync(phone, name, schoolName, eventType, request.Message, cancellationToken);
+
+        var now = GetCurrentLocalTime();
+        await AddAuditLogAsync(adminId, CelebrationAuditAction.TestSms, outcome.Success ? "Success" : outcome.Error, now, cancellationToken);
+
+        return new SmsSendResultDto
+        {
+            Success = outcome.Success,
+            Error = outcome.Error
+        };
+    }
+
+    public async Task<OptOutResponse> HandleOptOutAsync(OptOutRequest request, CancellationToken cancellationToken)
+    {
+        if (!TryNormalizePhone(request.Phone, out var phone, out var phoneError))
+        {
+            throw new ArgumentException(phoneError ?? "Invalid phone", nameof(request.Phone));
+        }
+
+        var message = request.Message?.Trim().ToUpperInvariant() ?? string.Empty;
+        if (!message.Contains("STOP", StringComparison.OrdinalIgnoreCase))
+        {
+            return new OptOutResponse { Updated = false };
+        }
+
+        var now = GetCurrentLocalTime();
+
+        var students = await _dbContext.CelebrationStudents
+            .Where(s => s.Phone == phone && s.Consent)
+            .ToListAsync(cancellationToken);
+
+        var teachers = await _dbContext.CelebrationTeachers
+            .Where(t => t.Phone == phone && t.Consent)
+            .ToListAsync(cancellationToken);
+
+        foreach (var student in students)
+        {
+            student.Consent = false;
+            student.UpdatedAt = now;
+        }
+
+        foreach (var teacher in teachers)
+        {
+            teacher.Consent = false;
+            teacher.UpdatedAt = now;
+        }
+
+        var updated = students.Count + teachers.Count;
+        if (updated > 0)
+        {
+            await _dbContext.SaveChangesAsync(cancellationToken);
+
+            var adminIds = students.Select(s => s.AdminId)
+                .Concat(teachers.Select(t => t.AdminId))
+                .Distinct()
+                .ToList();
+
+            foreach (var adminId in adminIds)
+            {
+                await AddAuditLogAsync(adminId, CelebrationAuditAction.OptOut, $"Phone {phone}", now, cancellationToken);
+            }
+        }
+
+        return new OptOutResponse { Updated = updated > 0 };
+    }
+
+    public async Task SendDailyRemindersAsync(CancellationToken cancellationToken)
+    {
+        var today = GetCurrentLocalDate();
+        var now = GetCurrentLocalTime();
+
+        var adminIds = await _dbContext.CelebrationStudents.Select(s => s.AdminId)
+            .Union(_dbContext.CelebrationTeachers.Select(t => t.AdminId))
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        foreach (var adminId in adminIds)
+        {
+            var schoolName = await _dbContext.CelebrationConfigurations
+                .AsNoTracking()
+                .Where(c => c.AdminId == adminId)
+                .Select(c => c.SchoolName)
+                .FirstOrDefaultAsync(cancellationToken) ?? "Your School";
+
+            await SendStudentMessagesAsync(adminId, schoolName, today, cancellationToken);
+            await SendTeacherMessagesAsync(adminId, schoolName, today, cancellationToken);
+
+            await AddAuditLogAsync(adminId, CelebrationAuditAction.Send, $"Daily reminders for {today:yyyy-MM-dd}", now, cancellationToken);
+        }
+
+        await PruneOldRecordsAsync(today, cancellationToken);
+    }
+
+    private async Task SendStudentMessagesAsync(int adminId, string schoolName, DateOnly date, CancellationToken cancellationToken)
+    {
+        var students = await _dbContext.CelebrationStudents
+            .Where(s => s.AdminId == adminId && s.Consent && s.DateOfBirth.Month == date.Month && s.DateOfBirth.Day == date.Day)
+            .ToListAsync(cancellationToken);
+
+        if (students.Count == 0)
+        {
+            return;
+        }
+
+        var existingLogs = await _dbContext.CelebrationLogs
+            .Where(l => l.AdminId == adminId && l.EventDate == date && l.RecipientType == CelebrationRecipientType.Student)
+            .ToListAsync(cancellationToken);
+
+        foreach (var student in students)
+        {
+            await SendWithRetriesAsync(adminId, schoolName, date, existingLogs, CelebrationRecipientType.Student, student.StudentId, student.Name, student.Phone, CelebrationEventType.Birthday, cancellationToken);
+        }
+    }
+
+    private async Task SendTeacherMessagesAsync(int adminId, string schoolName, DateOnly date, CancellationToken cancellationToken)
+    {
+        var teachers = await _dbContext.CelebrationTeachers
+            .Where(t => t.AdminId == adminId && t.Consent &&
+                        ((t.DateOfBirth.Month == date.Month && t.DateOfBirth.Day == date.Day) ||
+                         (t.Anniversary.HasValue && t.Anniversary.Value.Month == date.Month && t.Anniversary.Value.Day == date.Day)))
+            .ToListAsync(cancellationToken);
+
+        if (teachers.Count == 0)
+        {
+            return;
+        }
+
+        var existingLogs = await _dbContext.CelebrationLogs
+            .Where(l => l.AdminId == adminId && l.EventDate == date && l.RecipientType == CelebrationRecipientType.Teacher)
+            .ToListAsync(cancellationToken);
+
+        foreach (var teacher in teachers)
+        {
+            if (teacher.DateOfBirth.Month == date.Month && teacher.DateOfBirth.Day == date.Day)
+            {
+                await SendWithRetriesAsync(adminId, schoolName, date, existingLogs, CelebrationRecipientType.Teacher, teacher.TeacherId, teacher.Name, teacher.Phone, CelebrationEventType.Birthday, cancellationToken);
+            }
+
+            if (teacher.Anniversary.HasValue && teacher.Anniversary.Value.Month == date.Month && teacher.Anniversary.Value.Day == date.Day)
+            {
+                await SendWithRetriesAsync(adminId, schoolName, date, existingLogs, CelebrationRecipientType.Teacher, teacher.TeacherId, teacher.Name, teacher.Phone, CelebrationEventType.Anniversary, cancellationToken);
+            }
+        }
+    }
+
+    private async Task SendWithRetriesAsync(
+        int adminId,
+        string schoolName,
+        DateOnly date,
+        List<CelebrationLog> existingLogs,
+        CelebrationRecipientType recipientType,
+        int recipientId,
+        string name,
+        string phone,
+        CelebrationEventType eventType,
+        CancellationToken cancellationToken)
+    {
+        var attemptsToday = existingLogs
+            .Where(l => l.RecipientType == recipientType && l.RecipientId == recipientId && l.EventType == eventType)
+            .OrderBy(l => l.Attempt)
+            .ToList();
+
+        if (attemptsToday.Any(l => l.Status != CelebrationDeliveryStatus.Failed))
+        {
+            return;
+        }
+
+        for (var attemptIndex = attemptsToday.Count; attemptIndex < _options.SendRetryLimit; attemptIndex++)
+        {
+            var currentAttempt = attemptIndex + 1;
+            var attemptTime = GetCurrentLocalTime();
+            var outcome = await SendCelebrationMessageAsync(phone, name, schoolName, eventType, null, cancellationToken);
+
+            var log = new CelebrationLog
+            {
+                AdminId = adminId,
+                RecipientType = recipientType,
+                RecipientId = recipientId,
+                RecipientName = name,
+                EventType = eventType,
+                Phone = phone,
+                Message = outcome.Message,
+                Status = outcome.Success ? CelebrationDeliveryStatus.Sent : CelebrationDeliveryStatus.Failed,
+                FailureReason = outcome.Error,
+                Attempt = currentAttempt,
+                EventDate = date,
+                SentAt = attemptTime
+            };
+
+            _dbContext.CelebrationLogs.Add(log);
+            existingLogs.Add(log);
+
+            await _dbContext.SaveChangesAsync(cancellationToken);
+
+            if (outcome.Success)
+            {
+                break;
+            }
+        }
+    }
+
+    private async Task PruneOldRecordsAsync(DateOnly date, CancellationToken cancellationToken)
+    {
+        if (_options.LogRetentionDays <= 0)
+        {
+            return;
+        }
+
+        var cutoff = date.AddDays(-_options.LogRetentionDays);
+
+        var oldLogs = await _dbContext.CelebrationLogs
+            .Where(l => l.EventDate < cutoff)
+            .ToListAsync(cancellationToken);
+
+        if (oldLogs.Count > 0)
+        {
+            _dbContext.CelebrationLogs.RemoveRange(oldLogs);
+        }
+
+        var oldAudits = await _dbContext.CelebrationAuditLogs
+            .Where(a => DateOnly.FromDateTime(a.Timestamp.DateTime) < cutoff)
+            .ToListAsync(cancellationToken);
+
+        if (oldAudits.Count > 0)
+        {
+            _dbContext.CelebrationAuditLogs.RemoveRange(oldAudits);
+        }
+
+        if (oldLogs.Count > 0 || oldAudits.Count > 0)
+        {
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private async Task AddAuditLogAsync(int adminId, CelebrationAuditAction action, string? details, DateTimeOffset timestamp, CancellationToken cancellationToken)
+    {
+        var audit = new CelebrationAuditLog
+        {
+            AdminId = adminId,
+            Action = action,
+            Details = details,
+            Timestamp = timestamp
+        };
+
+        _dbContext.CelebrationAuditLogs.Add(audit);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task<SmsOutcome> SendCelebrationMessageAsync(string phone, string name, string schoolName, CelebrationEventType eventType, string? overrideMessage, CancellationToken cancellationToken)
+    {
+        var defaultMessage = ComposeDefaultMessage(eventType, name, schoolName);
+
+        if (!string.IsNullOrWhiteSpace(overrideMessage))
+        {
+            return await SendCustomMessageAsync(phone, overrideMessage!, cancellationToken);
+        }
+
+        var templateId = eventType == CelebrationEventType.Birthday
+            ? _options.BirthdayTemplateId
+            : _options.AnniversaryTemplateId;
+
+        if (string.IsNullOrWhiteSpace(templateId))
+        {
+            _logger.LogWarning("MSG91 template ID not configured for {EventType}. Falling back to custom message.", eventType);
+            return await SendCustomMessageAsync(phone, defaultMessage, cancellationToken);
+        }
+
+        var client = _httpClientFactory.CreateClient("msg91");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "api/v5/flow/");
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        request.Headers.TryAddWithoutValidation("authkey", _options.ApiKey);
+
+        var payload = new
+        {
+            flow_id = templateId,
+            sender = _options.SenderId,
+            recipients = new[]
+            {
+                new
+                {
+                    mobiles = StripPlus(phone),
+                    VAR1 = name,
+                    VAR2 = schoolName,
+                    PE_ID = _options.PeId
+                }
+            }
+        };
+
+        request.Content = new StringContent(JsonSerializer.Serialize(payload, SerializerOptions), Encoding.UTF8, "application/json");
+
+        try
+        {
+            using var response = await client.SendAsync(request, cancellationToken);
+            if (response.IsSuccessStatusCode)
+            {
+                return SmsOutcome.Success(defaultMessage);
+            }
+
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            _logger.LogWarning("MSG91 template send failed: {Status} {Body}", response.StatusCode, body);
+            return SmsOutcome.Failure(defaultMessage, $"MSG91 template error: {body}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send MSG91 template message");
+            return SmsOutcome.Failure(defaultMessage, ex.Message);
+        }
+    }
+
+    private async Task<SmsOutcome> SendCustomMessageAsync(string phone, string message, CancellationToken cancellationToken)
+    {
+        var client = _httpClientFactory.CreateClient("msg91");
+        using var request = new HttpRequestMessage(HttpMethod.Post, "api/v2/sendsms");
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        request.Headers.TryAddWithoutValidation("authkey", _options.ApiKey);
+
+        var payload = new
+        {
+            sender = _options.SenderId,
+            route = "4",
+            country = "91",
+            sms = new[]
+            {
+                new
+                {
+                    message,
+                    to = new[] { StripPlus(phone) }
+                }
+            }
+        };
+
+        request.Content = new StringContent(JsonSerializer.Serialize(payload, SerializerOptions), Encoding.UTF8, "application/json");
+
+        try
+        {
+            using var response = await client.SendAsync(request, cancellationToken);
+            if (response.IsSuccessStatusCode)
+            {
+                return SmsOutcome.Success(message);
+            }
+
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            _logger.LogWarning("MSG91 custom send failed: {Status} {Body}", response.StatusCode, body);
+            return SmsOutcome.Failure(message, $"MSG91 custom error: {body}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send MSG91 custom message");
+            return SmsOutcome.Failure(message, ex.Message);
+        }
+    }
+
+    private static string ComposeDefaultMessage(CelebrationEventType eventType, string name, string schoolName)
+    {
+        return eventType switch
+        {
+            CelebrationEventType.Anniversary => $"Happy Work Anniversary {name}! Thank you from {schoolName}. Reply STOP to opt-out.",
+            _ => $"Happy Birthday {name}! Wishing you joy from {schoolName}. Reply STOP to opt-out."
+        };
+    }
+
+    private static string StripPlus(string phone)
+    {
+        return phone.StartsWith("+") ? phone[1..] : phone;
+    }
+
+    private DateOnly GetCurrentLocalDate()
+    {
+        return DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(_timeProvider.GetUtcNow(), _timeZone).DateTime);
+    }
+
+    private DateTimeOffset GetCurrentLocalTime()
+    {
+        var utcNow = _timeProvider.GetUtcNow();
+        return TimeZoneInfo.ConvertTime(utcNow, _timeZone);
+    }
+
+    private static TimeZoneInfo ResolveTimeZone(string timeZoneId)
+    {
+        if (!string.IsNullOrWhiteSpace(timeZoneId))
+        {
+            try
+            {
+                return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+            }
+            catch (TimeZoneNotFoundException)
+            {
+            }
+            catch (InvalidTimeZoneException)
+            {
+            }
+        }
+
+        var fallbackIds = new[] { "Asia/Kolkata", "India Standard Time" };
+        foreach (var id in fallbackIds)
+        {
+            try
+            {
+                return TimeZoneInfo.FindSystemTimeZoneById(id);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+
+        return TimeZoneInfo.Utc;
+    }
+
+    private static bool TryNormalizeType(string? value, out CelebrationRecipientType type)
+    {
+        if (string.Equals(value, "student", StringComparison.OrdinalIgnoreCase))
+        {
+            type = CelebrationRecipientType.Student;
+            return true;
+        }
+
+        if (string.Equals(value, "teacher", StringComparison.OrdinalIgnoreCase))
+        {
+            type = CelebrationRecipientType.Teacher;
+            return true;
+        }
+
+        type = CelebrationRecipientType.Student;
+        return false;
+    }
+
+    private static bool TryNormalizePhone(string? value, out string phone, out string? error)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            phone = string.Empty;
+            error = "Phone number is required";
+            return false;
+        }
+
+        var digits = DigitsOnly.Matches(value)
+            .Select(m => m.Value)
+            .Aggregate(new StringBuilder(), (sb, part) => sb.Append(part), sb => sb.ToString());
+
+        if (digits.Length == 10)
+        {
+            phone = $"+91{digits}";
+            error = null;
+            return true;
+        }
+
+        if (digits.Length == 12 && digits.StartsWith("91", StringComparison.Ordinal))
+        {
+            phone = $"+{digits}";
+            error = null;
+            return true;
+        }
+
+        phone = string.Empty;
+        error = "Phone must be +91XXXXXXXXXX";
+        return false;
+    }
+
+    private static bool TryParseDate(string? value, out DateOnly date, out string? error)
+    {
+        if (DateOnly.TryParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out date))
+        {
+            error = null;
+            return true;
+        }
+
+        if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
+        {
+            date = DateOnly.FromDateTime(dt);
+            error = null;
+            return true;
+        }
+
+        date = default;
+        error = "Invalid DOB";
+        return false;
+    }
+
+    private static bool TryParseAnniversary(string? value, out DateOnly? anniversary, out string? error)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            anniversary = null;
+            error = null;
+            return true;
+        }
+
+        if (TryParseDate(value, out var date, out error))
+        {
+            anniversary = date;
+            return true;
+        }
+
+        error = "Invalid anniversary";
+        anniversary = null;
+        return false;
+    }
+
+    private static bool ParseConsent(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return true;
+        }
+
+        return value.Trim() switch
+        {
+            "0" => false,
+            "false" or "FALSE" => false,
+            _ => true
+        };
+    }
+
+    private static List<UploadRecord> ParseCsv(IFormFile file)
+    {
+        using var stream = file.OpenReadStream();
+        using var reader = new StreamReader(stream, leaveOpen: false);
+
+        var config = new CsvConfiguration(CultureInfo.InvariantCulture)
+        {
+            PrepareHeaderForMatch = args => args.Header.ToLowerInvariant(),
+            MissingFieldFound = null,
+            HeaderValidated = null,
+            TrimOptions = TrimOptions.Trim
+        };
+
+        using var csv = new CsvReader(reader, config);
+        var records = new List<UploadRecord>();
+
+        var rowNumber = 0;
+        while (csv.Read())
+        {
+            rowNumber = csv.Parser.RawRow;
+
+            if (csv.Parser.Record?.All(string.IsNullOrWhiteSpace) ?? true)
+            {
+                continue;
+            }
+
+            var record = new UploadRecord
+            {
+                RowNumber = rowNumber,
+                Type = csv.GetField("type"),
+                Name = csv.GetField("name"),
+                Dob = csv.GetField("dob"),
+                Anniversary = csv.GetField("anniversary"),
+                Phone = csv.GetField("phone"),
+                Consent = csv.GetField("consent")
+            };
+
+            records.Add(record);
+        }
+
+        return records;
+    }
+
+    private static List<UploadRecord> ParseExcel(IFormFile file)
+    {
+        RegisterExcelEncoding();
+
+        using var stream = file.OpenReadStream();
+        using var reader = ExcelReaderFactory.CreateReader(stream);
+
+        var headers = Array.Empty<string>();
+        var records = new List<UploadRecord>();
+        var rowNumber = 0;
+
+        do
+        {
+            while (reader.Read())
+            {
+                rowNumber++;
+
+                if (rowNumber == 1)
+                {
+                    headers = Enumerable.Range(0, reader.FieldCount)
+                        .Select(i => reader.GetValue(i)?.ToString()?.Trim().ToLowerInvariant() ?? string.Empty)
+                        .ToArray();
+                    continue;
+                }
+
+                if (headers.Length == 0 || headers.All(string.IsNullOrWhiteSpace))
+                {
+                    continue;
+                }
+
+                if (Enumerable.Range(0, headers.Length).All(i => string.IsNullOrWhiteSpace(reader.GetValue(i)?.ToString())))
+                {
+                    continue;
+                }
+
+                string? GetValue(string column)
+                {
+                    var index = Array.FindIndex(headers, h => h == column);
+                    if (index < 0 || index >= reader.FieldCount)
+                    {
+                        return null;
+                    }
+
+                    return reader.GetValue(index)?.ToString();
+                }
+
+                records.Add(new UploadRecord
+                {
+                    RowNumber = rowNumber,
+                    Type = GetValue("type"),
+                    Name = GetValue("name"),
+                    Dob = GetValue("dob"),
+                    Anniversary = GetValue("anniversary"),
+                    Phone = GetValue("phone"),
+                    Consent = GetValue("consent")
+                });
+            }
+        } while (reader.NextResult());
+
+        return records;
+    }
+
+    private static void RegisterExcelEncoding()
+    {
+        if (_encodingRegistered)
+        {
+            return;
+        }
+
+        lock (typeof(CelebrationService))
+        {
+            if (_encodingRegistered)
+            {
+                return;
+            }
+
+            System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+            _encodingRegistered = true;
+        }
+    }
+
+    private sealed class UploadRecord
+    {
+        public int RowNumber { get; set; }
+
+        public string? Type { get; set; }
+
+        public string? Name { get; set; }
+
+        public string? Dob { get; set; }
+
+        public string? Anniversary { get; set; }
+
+        public string? Phone { get; set; }
+
+        public string? Consent { get; set; }
+    }
+
+    private readonly record struct SmsOutcome(bool Success, string Message, string? Error)
+    {
+        public static SmsOutcome Success(string message) => new(true, message, null);
+
+        public static SmsOutcome Failure(string message, string? error) => new(false, message, error);
+    }
+}

--- a/edpicker-api/Services/Interface/ICelebrationService.cs
+++ b/edpicker-api/Services/Interface/ICelebrationService.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using edpicker_api.Models.Celebration.Dtos;
+using Microsoft.AspNetCore.Http;
+
+namespace edpicker_api.Services.Interface;
+
+public interface ICelebrationService
+{
+    Task<UploadProfilesResult> UploadProfilesAsync(int adminId, IFormFile file, CancellationToken cancellationToken);
+
+    Task<StudentSummaryDto> UpsertStudentAsync(int adminId, StudentUpsertRequest request, CancellationToken cancellationToken);
+
+    Task<TeacherEventDto> UpsertTeacherAsync(int adminId, TeacherUpsertRequest request, CancellationToken cancellationToken);
+
+    Task<TodayDashboardResponse> GetTodayDashboardAsync(int adminId, CancellationToken cancellationToken);
+
+    Task<HistoryResponse> GetHistoryAsync(int adminId, DateOnly date, CancellationToken cancellationToken);
+
+    Task<SchoolConfigResponse> SetSchoolNameAsync(int adminId, SchoolConfigRequest request, CancellationToken cancellationToken);
+
+    Task<SmsSendResultDto> SendTestSmsAsync(int adminId, SmsTestRequest request, CancellationToken cancellationToken);
+
+    Task<OptOutResponse> HandleOptOutAsync(OptOutRequest request, CancellationToken cancellationToken);
+
+    Task SendDailyRemindersAsync(CancellationToken cancellationToken);
+}

--- a/edpicker-api/appsettings.Development.json
+++ b/edpicker-api/appsettings.Development.json
@@ -7,5 +7,19 @@
     },
     "ConnectionStrings": {
         //"DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=assisischooldb;Trusted_Connection=True;MultipleActiveResultSets=true",
+    },
+    "DefaultConnection": "",
+    "Celebration": {
+        "BaseUrl": "https://api.msg91.com/",
+        "ApiKey": "",
+        "SenderId": "SCHLBDY",
+        "PeId": "",
+        "BirthdayTemplateId": "",
+        "AnniversaryTemplateId": "",
+        "NotificationHour": 9,
+        "NotificationMinute": 0,
+        "SendRetryLimit": 3,
+        "LogRetentionDays": 90,
+        "TimeZoneId": "Asia/Kolkata"
     }
 }

--- a/edpicker-api/appsettings.json
+++ b/edpicker-api/appsettings.json
@@ -18,5 +18,18 @@
         "OpenAIKeySecretName": "openaiapikey-dev",
         "DbPasswordSecretName": "edpickerdb-dev-password"
     },
-    "DefaultConnection": ""
+    "DefaultConnection": "",
+    "Celebration": {
+        "BaseUrl": "https://api.msg91.com/",
+        "ApiKey": "",
+        "SenderId": "SCHLBDY",
+        "PeId": "",
+        "BirthdayTemplateId": "",
+        "AnniversaryTemplateId": "",
+        "NotificationHour": 9,
+        "NotificationMinute": 0,
+        "SendRetryLimit": 3,
+        "LogRetentionDays": 90,
+        "TimeZoneId": "Asia/Kolkata"
+    }
 }

--- a/edpicker-api/edpicker-api.csproj
+++ b/edpicker-api/edpicker-api.csproj
@@ -14,13 +14,17 @@
 		<None Remove="Content\9thScience\iesc105.pdf" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
-		<PackageReference Include="Azure.Identity" Version="1.16.0" />
-		<PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
-		<PackageReference Include="CsvHelper" Version="33.0.1" />
-		<PackageReference Include="Humanizer.Core" Version="3.0.0-beta.54" />
-		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0-beta1" />
+        <ItemGroup>
+                <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
+                <PackageReference Include="Azure.Identity" Version="1.16.0" />
+                <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
+                <PackageReference Include="ExcelDataReader" Version="3.6.0" />
+                <PackageReference Include="ExcelDataReader.DataSet" Version="3.6.0" />
+                <PackageReference Include="Hangfire.AspNetCore" Version="1.8.14" />
+                <PackageReference Include="Hangfire.SqlServer" Version="1.8.14" />
+                <PackageReference Include="CsvHelper" Version="33.0.1" />
+                <PackageReference Include="Humanizer.Core" Version="3.0.0-beta.54" />
+                <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0-beta1" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.17" />
 		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />


### PR DESCRIPTION
## Summary
- add celebration schema entities, DTOs, and service interface to manage profiles, logs, and configuration
- implement CelebrationService and controller endpoints for uploads, dashboard views, SMS testing, and opt-out handling with MSG91 integration
- configure Hangfire scheduling, MSG91 HTTP client, and celebration settings in program startup and appsettings, including new NuGet dependencies

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dac44dd634832a9fca1ae097809a48